### PR TITLE
Update to 1.325

### DIFF
--- a/map/games/mega_new_elk.xml
+++ b/map/games/mega_new_elk.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <!DOCTYPE game SYSTEM "game.dtd">
 <game>
-  <info name="Mega New Elk" version="1.324"/>
+  <info name="Mega New Elk" version="1.325"/>
   <loader javaClass="games.strategy.triplea.TripleA"/>
   <triplea minimumVersion="1.8"/>
   <diceSides value="6"/>
@@ -4432,16 +4432,16 @@
 <attachment name="territoryAttachment" attachTo="Alberta" 					javaClass="TerritoryAttachment" type="territory">	<option name="production" value="1"/>														</attachment>
 <attachment name="territoryAttachment" attachTo="Aleppo-Deir ez Zor" 		javaClass="TerritoryAttachment" type="territory">	<option name="production" value="1"/>			</attachment>
 <attachment name="territoryAttachment" attachTo="Algarve" 					javaClass="TerritoryAttachment" type="territory">	<option name="production" value="1"/>														</attachment>
-<attachment name="territoryAttachment" attachTo="Algiers" 					javaClass="TerritoryAttachment" type="territory">	<option name="production" value="1"/>														</attachment>
+<attachment name="territoryAttachment" attachTo="Algiers" 					javaClass="TerritoryAttachment" type="territory">	<option name="production" value="2"/>														</attachment>
 <attachment name="territoryAttachment" attachTo="Alice Springs-Outback" 	javaClass="TerritoryAttachment" type="territory">	<option name="production" value="1"/>			</attachment>
 <attachment name="territoryAttachment" attachTo="Almaty" 					javaClass="TerritoryAttachment" type="territory">	<option name="production" value="1"/>		</attachment>
-<attachment name="territoryAttachment" attachTo="Alsace" 					javaClass="TerritoryAttachment" type="territory">	<option name="production" value="1"/>			</attachment>
+<attachment name="territoryAttachment" attachTo="Alsace" 					javaClass="TerritoryAttachment" type="territory">	<option name="production" value="2"/>			</attachment>
 <attachment name="territoryAttachment" attachTo="Amapa-Brazilian Guiana"	javaClass="TerritoryAttachment" type="territory">	<option name="production" value="1"/>			</attachment>
 <attachment name="territoryAttachment" attachTo="Amazonas" 					javaClass="TerritoryAttachment" type="territory">	<option name="production" value="1"/>			</attachment>
 <attachment name="territoryAttachment" attachTo="Ambon" 					javaClass="TerritoryAttachment" type="territory">	<option name="production" value="1"/>		</attachment>
 <attachment name="territoryAttachment" attachTo="Amur" 						javaClass="TerritoryAttachment" type="territory">	<option name="production" value="1"/>			</attachment>
 <attachment name="territoryAttachment" attachTo="Anadyr" 					javaClass="TerritoryAttachment" type="territory">	<option name="production" value="1"/>			</attachment>
-<attachment name="territoryAttachment" attachTo="Anchorage" 				javaClass="TerritoryAttachment" type="territory">	<option name="production" value="1"/>			</attachment>
+<attachment name="territoryAttachment" attachTo="Anchorage" 				javaClass="TerritoryAttachment" type="territory">	<option name="production" value="2"/>			</attachment>
 <attachment name="territoryAttachment" attachTo="Andalusia" 				javaClass="TerritoryAttachment" type="territory">	<option name="production" value="1"/>														</attachment>
 <attachment name="territoryAttachment" attachTo="Andaman Is." 				javaClass="TerritoryAttachment" type="territory">	<option name="production" value="1"/>			</attachment>
 <attachment name="territoryAttachment" attachTo="Angola" 					javaClass="TerritoryAttachment" type="territory">	<option name="production" value="1"/>			</attachment>
@@ -4449,35 +4449,35 @@
 <attachment name="territoryAttachment" attachTo="Ankara" 					javaClass="TerritoryAttachment" type="territory">	<option name="production" value="1"/>														</attachment>
 <attachment name="territoryAttachment" attachTo="Antalya" 					javaClass="TerritoryAttachment" type="territory">	<option name="production" value="1"/>														</attachment>
 <attachment name="territoryAttachment" attachTo="Aragon-Catalonia" 			javaClass="TerritoryAttachment" type="territory">	<option name="production" value="1"/>														</attachment>
-<attachment name="territoryAttachment" attachTo="Archangelsk" 				javaClass="TerritoryAttachment" type="territory">	<option name="production" value="1"/>		</attachment>
-<attachment name="territoryAttachment" attachTo="Arizona-New Mexico" 		javaClass="TerritoryAttachment" type="territory">	<option name="production" value="1"/>		</attachment>
+<attachment name="territoryAttachment" attachTo="Archangelsk" 				javaClass="TerritoryAttachment" type="territory">	<option name="production" value="2"/>		</attachment>
+<attachment name="territoryAttachment" attachTo="Arizona-New Mexico" 		javaClass="TerritoryAttachment" type="territory">	<option name="production" value="3"/>		</attachment>
 <attachment name="territoryAttachment" attachTo="Ascension Is." 			javaClass="TerritoryAttachment" type="territory">	<option name="production" value="1"/>			</attachment>
 <attachment name="territoryAttachment" attachTo="Asir" 						javaClass="TerritoryAttachment" type="territory">	<option name="production" value="1"/>														</attachment>
 <attachment name="territoryAttachment" attachTo="Astrakhan" 				javaClass="TerritoryAttachment" type="territory">	<option name="production" value="1"/>			</attachment>
 <attachment name="territoryAttachment" attachTo="Asturias" 					javaClass="TerritoryAttachment" type="territory">	<option name="production" value="1"/>			</attachment>
-<attachment name="territoryAttachment" attachTo="Athens-Cen.Greece" 		javaClass="TerritoryAttachment" type="territory">	<option name="production" value="1"/>		</attachment>
-<attachment name="territoryAttachment" attachTo="Atlanta-Georgia" 			javaClass="TerritoryAttachment" type="territory">	<option name="production" value="1"/>			</attachment>
+<attachment name="territoryAttachment" attachTo="Athens-Cen.Greece" 		javaClass="TerritoryAttachment" type="territory">	<option name="production" value="2"/>		</attachment>
+<attachment name="territoryAttachment" attachTo="Atlanta-Georgia" 			javaClass="TerritoryAttachment" type="territory">	<option name="production" value="3"/>			</attachment>
 <attachment name="territoryAttachment" attachTo="Atyrau" 					javaClass="TerritoryAttachment" type="territory">	<option name="production" value="1"/>														</attachment>
 <attachment name="territoryAttachment" attachTo="Auckland-N.New Zealand" 	javaClass="TerritoryAttachment" type="territory">	<option name="production" value="1"/>		</attachment>
 <attachment name="territoryAttachment" attachTo="Azores Is." 				javaClass="TerritoryAttachment" type="territory">	<option name="production" value="1"/>			</attachment>
-<attachment name="territoryAttachment" attachTo="Baden-Wurttemburg" 		javaClass="TerritoryAttachment" type="territory">	<option name="production" value="1"/>			</attachment>
+<attachment name="territoryAttachment" attachTo="Baden-Wurttemburg" 		javaClass="TerritoryAttachment" type="territory">	<option name="production" value="4"/>			</attachment>
 <attachment name="territoryAttachment" attachTo="Baffin Is." 				javaClass="TerritoryAttachment" type="territory">	<option name="production" value="1"/>			</attachment>
 <attachment name="territoryAttachment" attachTo="Baghdad" 					javaClass="TerritoryAttachment" type="territory">	<option name="production" value="1"/>			</attachment>
 <attachment name="territoryAttachment" attachTo="Bahamas" 					javaClass="TerritoryAttachment" type="territory">	<option name="production" value="1"/>														</attachment>
 <attachment name="territoryAttachment" attachTo="Bahia-Norde Este" 			javaClass="TerritoryAttachment" type="territory">	<option name="production" value="1"/>			</attachment>
 <attachment name="territoryAttachment" attachTo="Baja-Sonora" 				javaClass="TerritoryAttachment" type="territory">	<option name="production" value="1"/>			</attachment>
-<attachment name="territoryAttachment" attachTo="Baku-Azerbaijan" 			javaClass="TerritoryAttachment" type="territory">	<option name="production" value="1"/>														</attachment>
+<attachment name="territoryAttachment" attachTo="Baku-Azerbaijan" 			javaClass="TerritoryAttachment" type="territory">	<option name="production" value="4"/>														</attachment>
 <attachment name="territoryAttachment" attachTo="Bali-Sunda Is." 			javaClass="TerritoryAttachment" type="territory">	<option name="production" value="1"/>			</attachment>
-<attachment name="territoryAttachment" attachTo="Balikpapan-S.Borneo" 		javaClass="TerritoryAttachment" type="territory">	<option name="production" value="1"/>			</attachment>
-<attachment name="territoryAttachment" attachTo="Bangkok-Siam" 				javaClass="TerritoryAttachment" type="territory">	<option name="production" value="1"/>			</attachment>
+<attachment name="territoryAttachment" attachTo="Balikpapan-S.Borneo" 		javaClass="TerritoryAttachment" type="territory">	<option name="production" value="4"/>			</attachment>
+<attachment name="territoryAttachment" attachTo="Bangkok-Siam" 				javaClass="TerritoryAttachment" type="territory">	<option name="production" value="2"/>			</attachment>
 <attachment name="territoryAttachment" attachTo="Barat Daya Is." 			javaClass="TerritoryAttachment" type="territory">	<option name="production" value="1"/>			</attachment>
 <attachment name="territoryAttachment" attachTo="Basra" 					javaClass="TerritoryAttachment" type="territory">	<option name="production" value="1"/>														</attachment>
-<attachment name="territoryAttachment" attachTo="Batavia-W.Java" 			javaClass="TerritoryAttachment" type="territory">	<option name="production" value="1"/>			</attachment>
-<attachment name="territoryAttachment" attachTo="Bavaria" 					javaClass="TerritoryAttachment" type="territory">	<option name="production" value="1"/>			</attachment>
+<attachment name="territoryAttachment" attachTo="Batavia-W.Java" 			javaClass="TerritoryAttachment" type="territory">	<option name="production" value="3"/>			</attachment>
+<attachment name="territoryAttachment" attachTo="Bavaria" 					javaClass="TerritoryAttachment" type="territory">	<option name="production" value="4"/>			</attachment>
 <attachment name="territoryAttachment" attachTo="Bechuanaland" 				javaClass="TerritoryAttachment" type="territory">	<option name="production" value="1"/>														</attachment>
 <attachment name="territoryAttachment" attachTo="Belgian Congo" 			javaClass="TerritoryAttachment" type="territory">	<option name="production" value="1"/>			</attachment>
-<attachment name="territoryAttachment" attachTo="Belgium" 		javaClass="TerritoryAttachment" type="territory">	<option name="production" value="1"/>														</attachment>
-<attachment name="territoryAttachment" attachTo="Belgrade-Cen.Yugoslavia"	javaClass="TerritoryAttachment" type="territory">	<option name="production" value="1"/>														</attachment>
+<attachment name="territoryAttachment" attachTo="Belgium" 		javaClass="TerritoryAttachment" type="territory">	<option name="production" value="2"/>														</attachment>
+<attachment name="territoryAttachment" attachTo="Belgrade-Cen.Yugoslavia"	javaClass="TerritoryAttachment" type="territory">	<option name="production" value="2"/>														</attachment>
 <attachment name="territoryAttachment" attachTo="Bengal" 					javaClass="TerritoryAttachment" type="territory">	<option name="production" value="1"/>														</attachment>
 <attachment name="territoryAttachment" attachTo="Benghazi-Cyrenaica" 		javaClass="TerritoryAttachment" type="territory">	<option name="production" value="1"/>														</attachment>
 <attachment name="territoryAttachment" attachTo="Berar" 					javaClass="TerritoryAttachment" type="territory">	<option name="production" value="1"/>														</attachment>
@@ -4496,28 +4496,28 @@
 <attachment name="territoryAttachment" attachTo="Bialystok" 				javaClass="TerritoryAttachment" type="territory">	<option name="production" value="1"/>														</attachment>
 <attachment name="territoryAttachment" attachTo="Bogata-Colombia" 			javaClass="TerritoryAttachment" type="territory">	<option name="production" value="1"/>			</attachment>
 <attachment name="territoryAttachment" attachTo="Bolivia" 					javaClass="TerritoryAttachment" type="territory">	<option name="production" value="1"/>			</attachment>
-<attachment name="territoryAttachment" attachTo="Bombay" 					javaClass="TerritoryAttachment" type="territory">	<option name="production" value="1"/>		</attachment>
+<attachment name="territoryAttachment" attachTo="Bombay" 					javaClass="TerritoryAttachment" type="territory">	<option name="production" value="3"/>		</attachment>
 <attachment name="territoryAttachment" attachTo="Bona" 						javaClass="TerritoryAttachment" type="territory">	<option name="production" value="1"/>														</attachment>
 <attachment name="territoryAttachment" attachTo="Boran" 					javaClass="TerritoryAttachment" type="territory">	<option name="production" value="1"/>														</attachment>
-<attachment name="territoryAttachment" attachTo="Bordeaux-Gascony" 			javaClass="TerritoryAttachment" type="territory">	<option name="production" value="1"/>			</attachment>
-<attachment name="territoryAttachment" attachTo="Boston-New England" 		javaClass="TerritoryAttachment" type="territory">	<option name="production" value="1"/>			</attachment>
+<attachment name="territoryAttachment" attachTo="Bordeaux-Gascony" 			javaClass="TerritoryAttachment" type="territory">	<option name="production" value="2"/>			</attachment>
+<attachment name="territoryAttachment" attachTo="Boston-New England" 		javaClass="TerritoryAttachment" type="territory">	<option name="production" value="4"/>			</attachment>
 <attachment name="territoryAttachment" attachTo="Bratsk" 					javaClass="TerritoryAttachment" type="territory">	<option name="production" value="1"/>			</attachment>
 <attachment name="territoryAttachment" attachTo="Brest" 					javaClass="TerritoryAttachment" type="territory">	<option name="production" value="1"/>														</attachment>
 <attachment name="territoryAttachment" attachTo="Brisbane-Queensland" 		javaClass="TerritoryAttachment" type="territory">	<option name="production" value="1"/>			</attachment>
 <attachment name="territoryAttachment" attachTo="British Guiana" 			javaClass="TerritoryAttachment" type="territory">	<option name="production" value="1"/>			</attachment>
 <attachment name="territoryAttachment" attachTo="British Honduras" 			javaClass="TerritoryAttachment" type="territory">	<option name="production" value="1"/>			</attachment>
 <attachment name="territoryAttachment" attachTo="British Somaliland" 		javaClass="TerritoryAttachment" type="territory">	<option name="production" value="1"/>														</attachment>
-<attachment name="territoryAttachment" attachTo="Brittany" 					javaClass="TerritoryAttachment" type="territory">	<option name="production" value="1"/>														</attachment>
+<attachment name="territoryAttachment" attachTo="Brittany" 					javaClass="TerritoryAttachment" type="territory">	<option name="production" value="2"/>														</attachment>
 <attachment name="territoryAttachment" attachTo="Broome-Exmouth" 			javaClass="TerritoryAttachment" type="territory">	<option name="production" value="1"/>			</attachment>
-<attachment name="territoryAttachment" attachTo="Bryansk" 					javaClass="TerritoryAttachment" type="territory">	<option name="production" value="1"/>														</attachment>
-<attachment name="territoryAttachment" attachTo="Bucharest-Cen.Romania" 	javaClass="TerritoryAttachment" type="territory">	<option name="production" value="1"/>			</attachment>
-<attachment name="territoryAttachment" attachTo="Budapest-N.Hungary" 		javaClass="TerritoryAttachment" type="territory">	<option name="production" value="1"/>			</attachment>
+<attachment name="territoryAttachment" attachTo="Bryansk" 					javaClass="TerritoryAttachment" type="territory">	<option name="production" value="2"/>														</attachment>
+<attachment name="territoryAttachment" attachTo="Bucharest-Cen.Romania" 	javaClass="TerritoryAttachment" type="territory">	<option name="production" value="3"/>			</attachment>
+<attachment name="territoryAttachment" attachTo="Budapest-N.Hungary" 		javaClass="TerritoryAttachment" type="territory">	<option name="production" value="2"/>			</attachment>
 <attachment name="territoryAttachment" attachTo="Buenos Aires" 				javaClass="TerritoryAttachment" type="territory">	<option name="production" value="1"/>														</attachment>
 <attachment name="territoryAttachment" attachTo="Buru" 						javaClass="TerritoryAttachment" type="territory">	<option name="production" value="1"/>			</attachment>
 <attachment name="territoryAttachment" attachTo="Buryatia" 					javaClass="TerritoryAttachment" type="territory">	<option name="production" value="1"/>														</attachment>
 <attachment name="territoryAttachment" attachTo="Cairo-Egypt" 				javaClass="TerritoryAttachment" type="territory">	<option name="production" value="1"/>														</attachment>
-<attachment name="territoryAttachment" attachTo="Calais" 			javaClass="TerritoryAttachment" type="territory">	<option name="production" value="1"/>														</attachment>
-<attachment name="territoryAttachment" attachTo="Calcutta" 					javaClass="TerritoryAttachment" type="territory">	<option name="production" value="1"/>				</attachment>
+<attachment name="territoryAttachment" attachTo="Calais" 			javaClass="TerritoryAttachment" type="territory">	<option name="production" value="2"/>														</attachment>
+<attachment name="territoryAttachment" attachTo="Calcutta" 					javaClass="TerritoryAttachment" type="territory">	<option name="production" value="4"/>				</attachment>
 <attachment name="territoryAttachment" attachTo="Cambodia" 					javaClass="TerritoryAttachment" type="territory">	<option name="production" value="1"/>			</attachment>
 <attachment name="territoryAttachment" attachTo="Canary Is." 				javaClass="TerritoryAttachment" type="territory">	<option name="production" value="1"/>														</attachment>
 <attachment name="territoryAttachment" attachTo="Cape Town" 				javaClass="TerritoryAttachment" type="territory">	<option name="production" value="1"/>			</attachment>
@@ -4530,48 +4530,48 @@
 <attachment name="territoryAttachment" attachTo="Ceylon" 					javaClass="TerritoryAttachment" type="territory">	<option name="production" value="1"/>														</attachment>
 <attachment name="territoryAttachment" attachTo="Chad" 						javaClass="TerritoryAttachment" type="territory">	<option name="production" value="1"/>		</attachment>
 <attachment name="territoryAttachment" attachTo="Chahar" 					javaClass="TerritoryAttachment" type="territory">	<option name="production" value="1"/>														</attachment>
-<attachment name="territoryAttachment" attachTo="Charleston-Savannah" 		javaClass="TerritoryAttachment" type="territory">	<option name="production" value="1"/>														</attachment>
-<attachment name="territoryAttachment" attachTo="Charlotte-Carolina" 		javaClass="TerritoryAttachment" type="territory">	<option name="production" value="1"/>														</attachment>
+<attachment name="territoryAttachment" attachTo="Charleston-Savannah" 		javaClass="TerritoryAttachment" type="territory">	<option name="production" value="4"/>														</attachment>
+<attachment name="territoryAttachment" attachTo="Charlotte-Carolina" 		javaClass="TerritoryAttachment" type="territory">	<option name="production" value="3"/>														</attachment>
 <attachment name="territoryAttachment" attachTo="Chelyabinsk" 				javaClass="TerritoryAttachment" type="territory">	<option name="production" value="1"/>														</attachment>
-<attachment name="territoryAttachment" attachTo="Chengdu-Szechwan" 			javaClass="TerritoryAttachment" type="territory">	<option name="production" value="1"/>		</attachment>
-<attachment name="territoryAttachment" attachTo="Chernihiv" 				javaClass="TerritoryAttachment" type="territory">	<option name="production" value="1"/>														</attachment>
+<attachment name="territoryAttachment" attachTo="Chengdu-Szechwan" 			javaClass="TerritoryAttachment" type="territory">	<option name="production" value="2"/>		</attachment>
+<attachment name="territoryAttachment" attachTo="Chernihiv" 				javaClass="TerritoryAttachment" type="territory">	<option name="production" value="2"/>														</attachment>
 <attachment name="territoryAttachment" attachTo="Chersky" 					javaClass="TerritoryAttachment" type="territory">	<option name="production" value="1"/>			</attachment>
 <attachment name="territoryAttachment" attachTo="Chiang Mai" 				javaClass="TerritoryAttachment" type="territory">	<option name="production" value="1"/>			</attachment>
-<attachment name="territoryAttachment" attachTo="Chicago" 					javaClass="TerritoryAttachment" type="territory">	<option name="production" value="1"/>														</attachment>
+<attachment name="territoryAttachment" attachTo="Chicago" 					javaClass="TerritoryAttachment" type="territory">	<option name="production" value="5"/>														</attachment>
 <attachment name="territoryAttachment" attachTo="Chihuahua-Durango" 		javaClass="TerritoryAttachment" type="territory">	<option name="production" value="1"/>			</attachment>
 <attachment name="territoryAttachment" attachTo="Chile" 					javaClass="TerritoryAttachment" type="territory">	<option name="production" value="0"/>		<option name="isImpassable" value="true"/>	</attachment>
 <attachment name="territoryAttachment" attachTo="Christchurch-S.New Zealand" javaClass="TerritoryAttachment" type="territory">	<option name="production" value="1"/>		</attachment>
 <attachment name="territoryAttachment" attachTo="Christmas Is." 			javaClass="TerritoryAttachment" type="territory">	<option name="production" value="1"/>			</attachment>
-<attachment name="territoryAttachment" attachTo="Chubu" 					javaClass="TerritoryAttachment" type="territory">	<option name="production" value="1"/>		</attachment>
+<attachment name="territoryAttachment" attachTo="Chubu" 					javaClass="TerritoryAttachment" type="territory">	<option name="production" value="3"/>		</attachment>
 <attachment name="territoryAttachment" attachTo="Chukotka" 					javaClass="TerritoryAttachment" type="territory">	<option name="production" value="1"/>			</attachment>
-<attachment name="territoryAttachment" attachTo="Chungking" 				javaClass="TerritoryAttachment" type="territory">	<option name="production" value="1"/>													<option name="capital" value="Chinese"/>		</attachment>
-<attachment name="territoryAttachment" attachTo="Colorado" 					javaClass="TerritoryAttachment" type="territory">	<option name="production" value="1"/>		</attachment>
+<attachment name="territoryAttachment" attachTo="Chungking" 				javaClass="TerritoryAttachment" type="territory">	<option name="production" value="2"/>													<option name="capital" value="Chinese"/>		</attachment>
+<attachment name="territoryAttachment" attachTo="Colorado" 					javaClass="TerritoryAttachment" type="territory">	<option name="production" value="3"/>		</attachment>
 <attachment name="territoryAttachment" attachTo="Comoros" 					javaClass="TerritoryAttachment" type="territory">	<option name="production" value="1"/>			</attachment>
 <attachment name="territoryAttachment" attachTo="Cook Is." 					javaClass="TerritoryAttachment" type="territory">	<option name="production" value="1"/>			</attachment>
-<attachment name="territoryAttachment" attachTo="Copenhagen-Denmark" 		javaClass="TerritoryAttachment" type="territory">	<option name="production" value="1"/>													</attachment>
+<attachment name="territoryAttachment" attachTo="Copenhagen-Denmark" 		javaClass="TerritoryAttachment" type="territory">	<option name="production" value="2"/>													</attachment>
 <attachment name="territoryAttachment" attachTo="Corregidor-Mindoro Is." 	javaClass="TerritoryAttachment" type="territory">	<option name="production" value="1"/>			</attachment>
 <attachment name="territoryAttachment" attachTo="Corsica" 					javaClass="TerritoryAttachment" type="territory">	<option name="production" value="1"/>		</attachment>
 <attachment name="territoryAttachment" attachTo="Costa" 					javaClass="TerritoryAttachment" type="territory">	<option name="production" value="1"/>			</attachment>
 <attachment name="territoryAttachment" attachTo="Crete" 					javaClass="TerritoryAttachment" type="territory">	<option name="production" value="1"/>		</attachment>
-<attachment name="territoryAttachment" attachTo="Crimea" 					javaClass="TerritoryAttachment" type="territory">	<option name="production" value="1"/>														</attachment>
+<attachment name="territoryAttachment" attachTo="Crimea" 					javaClass="TerritoryAttachment" type="territory">	<option name="production" value="2"/>														</attachment>
 <attachment name="territoryAttachment" attachTo="Croatia" 					javaClass="TerritoryAttachment" type="territory">	<option name="production" value="1"/>		</attachment>
 <attachment name="territoryAttachment" attachTo="Cyprus" 					javaClass="TerritoryAttachment" type="territory">	<option name="production" value="1"/>														</attachment>
 <attachment name="territoryAttachment" attachTo="Da Nang-Annam" 			javaClass="TerritoryAttachment" type="territory">	<option name="production" value="1"/>														</attachment>
-<attachment name="territoryAttachment" attachTo="Dagestan" 					javaClass="TerritoryAttachment" type="territory">	<option name="production" value="1"/>														</attachment>
+<attachment name="territoryAttachment" attachTo="Dagestan" 					javaClass="TerritoryAttachment" type="territory">	<option name="production" value="2"/>														</attachment>
 <attachment name="territoryAttachment" attachTo="Dakar" 					javaClass="TerritoryAttachment" type="territory">	<option name="production" value="1"/>														</attachment>
-<attachment name="territoryAttachment" attachTo="Dakota" 					javaClass="TerritoryAttachment" type="territory">	<option name="production" value="1"/>		</attachment>
+<attachment name="territoryAttachment" attachTo="Dakota" 					javaClass="TerritoryAttachment" type="territory">	<option name="production" value="3"/>		</attachment>
 <attachment name="territoryAttachment" attachTo="Dalarna" 					javaClass="TerritoryAttachment" type="territory">	<option name="production" value="1"/>		</attachment>
 <attachment name="territoryAttachment" attachTo="Dalmatia" 					javaClass="TerritoryAttachment" type="territory">	<option name="production" value="1"/>														</attachment>
 <attachment name="territoryAttachment" attachTo="Damascus-S.Syria" 			javaClass="TerritoryAttachment" type="territory">	<option name="production" value="1"/>														</attachment>
 <attachment name="territoryAttachment" attachTo="Danakil" 					javaClass="TerritoryAttachment" type="territory">	<option name="production" value="1"/>														</attachment>
-<attachment name="territoryAttachment" attachTo="Danzig-Posen" 				javaClass="TerritoryAttachment" type="territory">	<option name="production" value="1"/>														</attachment>
+<attachment name="territoryAttachment" attachTo="Danzig-Posen" 				javaClass="TerritoryAttachment" type="territory">	<option name="production" value="2"/>														</attachment>
 <attachment name="territoryAttachment" attachTo="Dar es Salaam-Zanzibar" 	javaClass="TerritoryAttachment" type="territory">	<option name="production" value="1"/>														</attachment>
 <attachment name="territoryAttachment" attachTo="Darfur" 					javaClass="TerritoryAttachment" type="territory">	<option name="production" value="1"/>														</attachment>
 <attachment name="territoryAttachment" attachTo="Darwin-Northern Territory" javaClass="TerritoryAttachment" type="territory">	<option name="production" value="1"/>			</attachment>
 <attachment name="territoryAttachment" attachTo="Demyansk" 					javaClass="TerritoryAttachment" type="territory">	<option name="production" value="1"/>														</attachment>
 <attachment name="territoryAttachment" attachTo="Diyarbakir" 				javaClass="TerritoryAttachment" type="territory">	<option name="production" value="1"/>														</attachment>
 <attachment name="territoryAttachment" attachTo="Dodecanese Is." 			javaClass="TerritoryAttachment" type="territory">	<option name="production" value="1"/>			</attachment>
-<attachment name="territoryAttachment" attachTo="Dovao-Mindonao" 			javaClass="TerritoryAttachment" type="territory">	<option name="production" value="1"/>			</attachment>
+<attachment name="territoryAttachment" attachTo="Dovao-Mindonao" 			javaClass="TerritoryAttachment" type="territory">	<option name="production" value="2"/>			</attachment>
 <attachment name="territoryAttachment" attachTo="Dutch Guiana" 				javaClass="TerritoryAttachment" type="territory">	<option name="production" value="1"/>			</attachment>
 <attachment name="territoryAttachment" attachTo="Dutch Harbor-Aleutian Is." javaClass="TerritoryAttachment" type="territory">	<option name="production" value="1"/>			</attachment>
 <attachment name="territoryAttachment" attachTo="Dzavhan" 					javaClass="TerritoryAttachment" type="territory">	<option name="production" value="1"/>														</attachment>
@@ -4593,8 +4593,8 @@
 <attachment name="territoryAttachment" attachTo="Fars" 						javaClass="TerritoryAttachment" type="territory">	<option name="production" value="1"/>													</attachment>
 <attachment name="territoryAttachment" attachTo="Fezzan" 					javaClass="TerritoryAttachment" type="territory">	<option name="production" value="1"/>			</attachment>	<!--   -->
 <attachment name="territoryAttachment" attachTo="Fiji" 						javaClass="TerritoryAttachment" type="territory">	<option name="production" value="1"/>			</attachment>
-<attachment name="territoryAttachment" attachTo="Florida" 					javaClass="TerritoryAttachment" type="territory">	<option name="production" value="1"/>			</attachment>
-<attachment name="territoryAttachment" attachTo="Frankfurt-Hesse" 			javaClass="TerritoryAttachment" type="territory">	<option name="production" value="1"/>			</attachment>
+<attachment name="territoryAttachment" attachTo="Florida" 					javaClass="TerritoryAttachment" type="territory">	<option name="production" value="4"/>			</attachment>
+<attachment name="territoryAttachment" attachTo="Frankfurt-Hesse" 			javaClass="TerritoryAttachment" type="territory">	<option name="production" value="4"/>			</attachment>
 <attachment name="territoryAttachment" attachTo="French Dahomey" 			javaClass="TerritoryAttachment" type="territory">	<option name="production" value="1"/>			</attachment>
 <attachment name="territoryAttachment" attachTo="Cameroon" 					javaClass="TerritoryAttachment" type="territory">	<option name="production" value="1"/>			</attachment>
 <attachment name="territoryAttachment" attachTo="French Guiana" 			javaClass="TerritoryAttachment" type="territory">	<option name="production" value="1"/>			</attachment>
@@ -4612,47 +4612,59 @@
 <attachment name="territoryAttachment" attachTo="Grand Erg" 				javaClass="TerritoryAttachment" type="territory">	<option name="production" value="1"/>			</attachment>
 <attachment name="territoryAttachment" attachTo="Greenland" 				javaClass="TerritoryAttachment" type="territory">	<option name="production" value="1"/>			</attachment>
 <attachment name="territoryAttachment" attachTo="Grodno" 					javaClass="TerritoryAttachment" type="territory">	<option name="production" value="1"/>														</attachment>
-<attachment name="territoryAttachment" attachTo="Grozny-Chechnya" 			javaClass="TerritoryAttachment" type="territory">	<option name="production" value="1"/>													</attachment>
-<attachment name="territoryAttachment" attachTo="Guadalcanal-Solomon Is."	javaClass="TerritoryAttachment" type="territory">	<option name="production" value="1"/>			</attachment>
+<attachment name="territoryAttachment" attachTo="Grozny-Chechnya" 			javaClass="TerritoryAttachment" type="territory">	<option name="production" value="3"/>													</attachment>
+<attachment name="territoryAttachment" attachTo="Guadalcanal-Solomon Is."	javaClass="TerritoryAttachment" type="territory">	<option name="production" value="2"/>			</attachment>
 <attachment name="territoryAttachment" attachTo="Guatemala" 				javaClass="TerritoryAttachment" type="territory">	<option name="production" value="1"/>			</attachment>
 <attachment name="territoryAttachment" attachTo="Gujarat" 					javaClass="TerritoryAttachment" type="territory">	<option name="production" value="1"/>			</attachment>
 <attachment name="territoryAttachment" attachTo="Haditha-Rutbah" 			javaClass="TerritoryAttachment" type="territory">	<option name="production" value="1"/>			</attachment>
-<attachment name="territoryAttachment" attachTo="Haichow-Lunghai" 			javaClass="TerritoryAttachment" type="territory">	<option name="production" value="1"/>														</attachment>
+<attachment name="territoryAttachment" attachTo="Haichow-Lunghai" 			javaClass="TerritoryAttachment" type="territory">	
+	<option name="production" value="2"/>														
+	<option name="originalOwner" value="Chinese"/>	
+</attachment>
 <attachment name="territoryAttachment" attachTo="Haikou-Hainan" 			javaClass="TerritoryAttachment" type="territory">	<option name="production" value="1"/>														</attachment>
 <attachment name="territoryAttachment" attachTo="Hail" 						javaClass="TerritoryAttachment" type="territory">	<option name="production" value="1"/>			</attachment>
 <attachment name="territoryAttachment" attachTo="Hailar-Hsingan" 			javaClass="TerritoryAttachment" type="territory">	<option name="production" value="1"/>			</attachment>
 <attachment name="territoryAttachment" attachTo="Halfa" 					javaClass="TerritoryAttachment" type="territory">	<option name="production" value="1"/>		</attachment>
 <attachment name="territoryAttachment" attachTo="Halifax-Nova Scotia" 		javaClass="TerritoryAttachment" type="territory">	<option name="production" value="1"/>			</attachment>
 <attachment name="territoryAttachment" attachTo="Halmahera-Maluku Is." 		javaClass="TerritoryAttachment" type="territory">	<option name="production" value="1"/>			</attachment>
-<attachment name="territoryAttachment" attachTo="Hamburg" 		javaClass="TerritoryAttachment" type="territory">	<option name="production" value="1"/>														</attachment>
-<attachment name="territoryAttachment" attachTo="Hanoi-Tonkin" 				javaClass="TerritoryAttachment" type="territory">	<option name="production" value="1"/>			</attachment>
-<attachment name="territoryAttachment" attachTo="Harbin" 					javaClass="TerritoryAttachment" type="territory">	<option name="production" value="1"/>														</attachment>
-<attachment name="territoryAttachment" attachTo="Havana-Cuba" 				javaClass="TerritoryAttachment" type="territory">	<option name="production" value="1"/>														</attachment>
-<attachment name="territoryAttachment" attachTo="Hawaiian Is." 				javaClass="TerritoryAttachment" type="territory">	<option name="production" value="1"/>		</attachment>
-<attachment name="territoryAttachment" attachTo="Helsinki" 					javaClass="TerritoryAttachment" type="territory">	<option name="production" value="1"/>				</attachment>
+<attachment name="territoryAttachment" attachTo="Hamburg" 		javaClass="TerritoryAttachment" type="territory">	<option name="production" value="4"/>														</attachment>
+<attachment name="territoryAttachment" attachTo="Hanoi-Tonkin" 				javaClass="TerritoryAttachment" type="territory">	<option name="production" value="2"/>			</attachment>
+<attachment name="territoryAttachment" attachTo="Harbin" 					javaClass="TerritoryAttachment" type="territory">	
+	<option name="production" value="1"/>		
+	<option name="originalOwner" value="Chinese"/>													
+</attachment>
+<attachment name="territoryAttachment" attachTo="Havana-Cuba" 				javaClass="TerritoryAttachment" type="territory">	<option name="production" value="3"/>														</attachment>
+<attachment name="territoryAttachment" attachTo="Hawaiian Is." 				javaClass="TerritoryAttachment" type="territory">	<option name="production" value="3"/>		</attachment>
+<attachment name="territoryAttachment" attachTo="Helsinki" 					javaClass="TerritoryAttachment" type="territory">	<option name="production" value="2"/>				</attachment>
 <attachment name="territoryAttachment" attachTo="Herat" 					javaClass="TerritoryAttachment" type="territory">	<option name="production" value="1"/>														</attachment>
 <attachment name="territoryAttachment" attachTo="Himalayas" 				javaClass="TerritoryAttachment" type="territory">	<option name="production" value="0"/>		<option name="isImpassable" value="true"/>	</attachment>
-<attachment name="territoryAttachment" attachTo="Hiroshima" 				javaClass="TerritoryAttachment" type="territory">	<option name="production" value="1"/>		</attachment>
-<attachment name="territoryAttachment" attachTo="Hokkaido" 					javaClass="TerritoryAttachment" type="territory">	<option name="production" value="1"/>		</attachment>
-<attachment name="territoryAttachment" attachTo="Hollandia-Dutch New Guinea" javaClass="TerritoryAttachment" type="territory">	<option name="production" value="1"/>			</attachment>
+<attachment name="territoryAttachment" attachTo="Hiroshima" 				javaClass="TerritoryAttachment" type="territory">	<option name="production" value="2"/>		</attachment>
+<attachment name="territoryAttachment" attachTo="Hokkaido" 					javaClass="TerritoryAttachment" type="territory">	<option name="production" value="2"/>		</attachment>
+<attachment name="territoryAttachment" attachTo="Hollandia-Dutch New Guinea" javaClass="TerritoryAttachment" type="territory">	<option name="production" value="2"/>			</attachment>
 <attachment name="territoryAttachment" attachTo="Honduras" 					javaClass="TerritoryAttachment" type="territory">	<option name="production" value="1"/>			</attachment>
-<attachment name="territoryAttachment" attachTo="Hong Kong-Kwangtung" 		javaClass="TerritoryAttachment" type="territory">	<option name="production" value="1"/>														</attachment>
-<attachment name="territoryAttachment" attachTo="Honolulu-Pearl Harbor" 	javaClass="TerritoryAttachment" type="territory">	<option name="production" value="1"/>				</attachment>
-<attachment name="territoryAttachment" attachTo="Hopei" 					javaClass="TerritoryAttachment" type="territory">	<option name="production" value="1"/>														</attachment>
-<attachment name="territoryAttachment" attachTo="Philadelphia-Pennsylvania" javaClass="TerritoryAttachment" type="territory">	<option name="production" value="1"/>			</attachment>
+<attachment name="territoryAttachment" attachTo="Hong Kong-Kwangtung" 		javaClass="TerritoryAttachment" type="territory">	<option name="production" value="3"/>														</attachment>
+<attachment name="territoryAttachment" attachTo="Honolulu-Pearl Harbor" 	javaClass="TerritoryAttachment" type="territory">	<option name="production" value="4"/>				</attachment>
+<attachment name="territoryAttachment" attachTo="Hopei" javaClass="TerritoryAttachment" type="territory">	
+	<option name="production" value="1"/>														
+	<option name="originalOwner" value="Chinese"/>	
+</attachment>
+<attachment name="territoryAttachment" attachTo="Philadelphia-Pennsylvania" javaClass="TerritoryAttachment" type="territory">	<option name="production" value="4"/>			</attachment>
 <attachment name="territoryAttachment" attachTo="Hunan" 					javaClass="TerritoryAttachment" type="territory">	<option name="production" value="1"/>														</attachment>
 <attachment name="territoryAttachment" attachTo="Hyderabad" 				javaClass="TerritoryAttachment" type="territory">	<option name="production" value="1"/>														</attachment>
 <attachment name="territoryAttachment" attachTo="Iceland" 					javaClass="TerritoryAttachment" type="territory">	<option name="production" value="1"/>		</attachment>
-<attachment name="territoryAttachment" attachTo="Idaho" 					javaClass="TerritoryAttachment" type="territory">	<option name="production" value="1"/>			</attachment>
+<attachment name="territoryAttachment" attachTo="Idaho" 					javaClass="TerritoryAttachment" type="territory">	<option name="production" value="3"/>			</attachment>
 <attachment name="territoryAttachment" attachTo="Irkutsk" 					javaClass="TerritoryAttachment" type="territory">	<option name="production" value="1"/>			</attachment>
 <attachment name="territoryAttachment" attachTo="Isfahan" 					javaClass="TerritoryAttachment" type="territory">	<option name="production" value="1"/>														</attachment>
 <attachment name="territoryAttachment" attachTo="Istanbul" 					javaClass="TerritoryAttachment" type="territory">	<option name="production" value="1"/>			</attachment>
 <attachment name="territoryAttachment" attachTo="Istria" 					javaClass="TerritoryAttachment" type="territory">	<option name="production" value="1"/>			</attachment>
 <attachment name="territoryAttachment" attachTo="Italian Somaliland" 		javaClass="TerritoryAttachment" type="territory">	<option name="production" value="1"/>														</attachment>
 <attachment name="territoryAttachment" attachTo="Ivory Coast" 				javaClass="TerritoryAttachment" type="territory">	<option name="production" value="1"/>			</attachment>
-<attachment name="territoryAttachment" attachTo="Iwo Jima-Bonin Is." 		javaClass="TerritoryAttachment" type="territory">	<option name="production" value="1"/>		</attachment>
+<attachment name="territoryAttachment" attachTo="Iwo Jima-Bonin Is." 		javaClass="TerritoryAttachment" type="territory">	<option name="production" value="3"/>		</attachment>
 <attachment name="territoryAttachment" attachTo="Jamaica" 					javaClass="TerritoryAttachment" type="territory">	<option name="production" value="1"/>			</attachment>
-<attachment name="territoryAttachment" attachTo="Jehol-Rehe" 				javaClass="TerritoryAttachment" type="territory">	<option name="production" value="1"/>														</attachment>
+<attachment name="territoryAttachment" attachTo="Jehol-Rehe" 				javaClass="TerritoryAttachment" type="territory">	
+	<option name="production" value="2"/>
+	<option name="originalOwner" value="Chinese"/>															
+</attachment>
 <attachment name="territoryAttachment" attachTo="Johnston Is." 				javaClass="TerritoryAttachment" type="territory">	<option name="production" value="1"/>			</attachment>
 <attachment name="territoryAttachment" attachTo="Jordan" 					javaClass="TerritoryAttachment" type="territory">	<option name="production" value="1"/>			</attachment>
 <attachment name="territoryAttachment" attachTo="Juba-S.Sudan" 				javaClass="TerritoryAttachment" type="territory">	<option name="production" value="1"/>		</attachment>
@@ -4663,24 +4675,24 @@
 <attachment name="territoryAttachment" attachTo="Kamchatka" 				javaClass="TerritoryAttachment" type="territory">	<option name="production" value="1"/>		</attachment>
 <attachment name="territoryAttachment" attachTo="Kanchow" 					javaClass="TerritoryAttachment" type="territory">	<option name="production" value="1"/>														</attachment>
 <attachment name="territoryAttachment" attachTo="Kandahar" 					javaClass="TerritoryAttachment" type="territory">	<option name="production" value="1"/>														</attachment>
-<attachment name="territoryAttachment" attachTo="Kansas-Oklahoma" 			javaClass="TerritoryAttachment" type="territory">	<option name="production" value="1"/>														</attachment>
-<attachment name="territoryAttachment" attachTo="Karachi" 					javaClass="TerritoryAttachment" type="territory">	<option name="production" value="1"/>														</attachment>
+<attachment name="territoryAttachment" attachTo="Kansas-Oklahoma" 			javaClass="TerritoryAttachment" type="territory">	<option name="production" value="3"/>														</attachment>
+<attachment name="territoryAttachment" attachTo="Karachi" 					javaClass="TerritoryAttachment" type="territory">	<option name="production" value="2"/>														</attachment>
 <attachment name="territoryAttachment" attachTo="Karelia" 					javaClass="TerritoryAttachment" type="territory">	<option name="production" value="1"/>			</attachment>
 <attachment name="territoryAttachment" attachTo="Kashmire" 					javaClass="TerritoryAttachment" type="territory">	<option name="production" value="1"/>														</attachment>
 <attachment name="territoryAttachment" attachTo="Katanga" 					javaClass="TerritoryAttachment" type="territory">	<option name="production" value="1"/>														</attachment>
-<attachment name="territoryAttachment" attachTo="Kazan" 					javaClass="TerritoryAttachment" type="territory">	<option name="production" value="1"/>														</attachment>
-<attachment name="territoryAttachment" attachTo="Kendari-E.Celebs" 			javaClass="TerritoryAttachment" type="territory">	<option name="production" value="1"/>			</attachment>
-<attachment name="territoryAttachment" attachTo="Kentucky-Tennessee" 		javaClass="TerritoryAttachment" type="territory">	<option name="production" value="1"/>														</attachment>
+<attachment name="territoryAttachment" attachTo="Kazan" 					javaClass="TerritoryAttachment" type="territory">	<option name="production" value="2"/>														</attachment>
+<attachment name="territoryAttachment" attachTo="Kendari-E.Celebs" 			javaClass="TerritoryAttachment" type="territory">	<option name="production" value="2"/>			</attachment>
+<attachment name="territoryAttachment" attachTo="Kentucky-Tennessee" 		javaClass="TerritoryAttachment" type="territory">	<option name="production" value="3"/>														</attachment>
 <attachment name="territoryAttachment" attachTo="Kenya" 					javaClass="TerritoryAttachment" type="territory">	<option name="production" value="1"/>														</attachment>
 <attachment name="territoryAttachment" attachTo="Kerman" 					javaClass="TerritoryAttachment" type="territory">	<option name="production" value="1"/>														</attachment>
 <attachment name="territoryAttachment" attachTo="Khabarovsk" 				javaClass="TerritoryAttachment" type="territory">	<option name="production" value="1"/>														</attachment>
 <attachment name="territoryAttachment" attachTo="Khanty-Mansiysk" 			javaClass="TerritoryAttachment" type="territory">	<option name="production" value="1"/>			</attachment>
 <attachment name="territoryAttachment" attachTo="Kharga-Western Desert" 	javaClass="TerritoryAttachment" type="territory">	<option name="production" value="1"/>			</attachment>
-<attachment name="territoryAttachment" attachTo="Kharkiv" 					javaClass="TerritoryAttachment" type="territory">	<option name="production" value="1"/>														</attachment>
+<attachment name="territoryAttachment" attachTo="Kharkiv" 					javaClass="TerritoryAttachment" type="territory">	<option name="production" value="2"/>														</attachment>
 <attachment name="territoryAttachment" attachTo="Khartoum-Sudan" 			javaClass="TerritoryAttachment" type="territory">	<option name="production" value="1"/>														</attachment>
 <attachment name="territoryAttachment" attachTo="Kherson" 					javaClass="TerritoryAttachment" type="territory">	<option name="production" value="1"/>														</attachment>
 <attachment name="territoryAttachment" attachTo="Khorasan" 					javaClass="TerritoryAttachment" type="territory">	<option name="production" value="1"/>														</attachment>
-<attachment name="territoryAttachment" attachTo="Kiangsi" 					javaClass="TerritoryAttachment" type="territory">	<option name="production" value="1"/>														</attachment>
+<attachment name="territoryAttachment" attachTo="Kiangsi" 					javaClass="TerritoryAttachment" type="territory">	<option name="production" value="2"/>														</attachment>
 <attachment name="territoryAttachment" attachTo="Kilwa" 					javaClass="TerritoryAttachment" type="territory">	<option name="production" value="1"/>														</attachment>
 <attachment name="territoryAttachment" attachTo="King Salmon-Aleut Pen." 	javaClass="TerritoryAttachment" type="territory">	<option name="production" value="1"/>			</attachment>
 <attachment name="territoryAttachment" attachTo="Kirov" 					javaClass="TerritoryAttachment" type="territory">	<option name="production" value="1"/>			</attachment>
@@ -4689,27 +4701,27 @@
 <attachment name="territoryAttachment" attachTo="Kolyma" 					javaClass="TerritoryAttachment" type="territory">	<option name="production" value="1"/>			</attachment>
 <attachment name="territoryAttachment" attachTo="Komi" 						javaClass="TerritoryAttachment" type="territory">	<option name="production" value="1"/>		</attachment>
 <attachment name="territoryAttachment" attachTo="Konduz" 					javaClass="TerritoryAttachment" type="territory">	<option name="production" value="1"/>														</attachment>
-<attachment name="territoryAttachment" attachTo="Konigsberg-E.Prussia" 		javaClass="TerritoryAttachment" type="territory">	<option name="production" value="1"/>			</attachment>
+<attachment name="territoryAttachment" attachTo="Konigsberg-E.Prussia" 		javaClass="TerritoryAttachment" type="territory">	<option name="production" value="2"/>			</attachment>
 <attachment name="territoryAttachment" attachTo="Konya" 					javaClass="TerritoryAttachment" type="territory">	<option name="production" value="1"/>														</attachment>
 <attachment name="territoryAttachment" attachTo="Koryak" 					javaClass="TerritoryAttachment" type="territory">	<option name="production" value="1"/>														</attachment>
 <attachment name="territoryAttachment" attachTo="Kosice-Munkacs" 			javaClass="TerritoryAttachment" type="territory">	<option name="production" value="1"/>														</attachment>
 <attachment name="territoryAttachment" attachTo="Kra-Buri" 					javaClass="TerritoryAttachment" type="territory">	<option name="production" value="1"/>			</attachment>
-<attachment name="territoryAttachment" attachTo="Krakow-Lublin" 			javaClass="TerritoryAttachment" type="territory">	<option name="production" value="1"/>														</attachment>
+<attachment name="territoryAttachment" attachTo="Krakow-Lublin" 			javaClass="TerritoryAttachment" type="territory">	<option name="production" value="2"/>														</attachment>
 <attachment name="territoryAttachment" attachTo="Krasnodar" 				javaClass="TerritoryAttachment" type="territory">	<option name="production" value="1"/>													</attachment>
 <attachment name="territoryAttachment" attachTo="Krasnoyarsk" 				javaClass="TerritoryAttachment" type="territory">	<option name="production" value="1"/>														</attachment>
 <attachment name="territoryAttachment" attachTo="Kunming" 					javaClass="TerritoryAttachment" type="territory">	<option name="production" value="1"/>														</attachment>
 <attachment name="territoryAttachment" attachTo="Kurdistan" 				javaClass="TerritoryAttachment" type="territory">	<option name="production" value="1"/>														</attachment>
 <attachment name="territoryAttachment" attachTo="Kurgan" 					javaClass="TerritoryAttachment" type="territory">	<option name="production" value="1"/>														</attachment>
-<attachment name="territoryAttachment" attachTo="Kursk-Vorozneh" 			javaClass="TerritoryAttachment" type="territory">	<option name="production" value="1"/>														</attachment>
+<attachment name="territoryAttachment" attachTo="Kursk-Vorozneh" 			javaClass="TerritoryAttachment" type="territory">	<option name="production" value="2"/>														</attachment>
 <attachment name="territoryAttachment" attachTo="Kuwait" 					javaClass="TerritoryAttachment" type="territory">	<option name="production" value="1"/>			</attachment>
-<attachment name="territoryAttachment" attachTo="Kuybysev" 					javaClass="TerritoryAttachment" type="territory">	<option name="production" value="1"/>			</attachment>
+<attachment name="territoryAttachment" attachTo="Kuybysev" 					javaClass="TerritoryAttachment" type="territory">	<option name="production" value="2"/>			</attachment>
 <attachment name="territoryAttachment" attachTo="Kwajalein-Marshall Is." 	javaClass="TerritoryAttachment" type="territory">	<option name="production" value="1"/>			</attachment>
-<attachment name="territoryAttachment" attachTo="Kwangsi" 					javaClass="TerritoryAttachment" type="territory">	<option name="production" value="1"/>														</attachment>
+<attachment name="territoryAttachment" attachTo="Kwangsi" 					javaClass="TerritoryAttachment" type="territory">	<option name="production" value="2"/>														</attachment>
 <attachment name="territoryAttachment" attachTo="Kweichow" 					javaClass="TerritoryAttachment" type="territory">	<option name="production" value="1"/>			</attachment>
-<attachment name="territoryAttachment" attachTo="Kyiv-Cen.Ukraine" 			javaClass="TerritoryAttachment" type="territory">	<option name="production" value="1"/>														</attachment>
-<attachment name="territoryAttachment" attachTo="Kyoto-Osaka" 				javaClass="TerritoryAttachment" type="territory">	<option name="production" value="1"/>			</attachment>
+<attachment name="territoryAttachment" attachTo="Kyiv-Cen.Ukraine" 			javaClass="TerritoryAttachment" type="territory">	<option name="production" value="3"/>														</attachment>
+<attachment name="territoryAttachment" attachTo="Kyoto-Osaka" 				javaClass="TerritoryAttachment" type="territory">	<option name="production" value="3"/>			</attachment>
 <attachment name="territoryAttachment" attachTo="Kyrgyzstan-Tajikistan" 	javaClass="TerritoryAttachment" type="territory">	<option name="production" value="1"/>		</attachment>
-<attachment name="territoryAttachment" attachTo="Kyushu" 					javaClass="TerritoryAttachment" type="territory">	<option name="production" value="1"/>			</attachment>
+<attachment name="territoryAttachment" attachTo="Kyushu" 					javaClass="TerritoryAttachment" type="territory">	<option name="production" value="4"/>			</attachment>
 <attachment name="territoryAttachment" attachTo="Labrador" 					javaClass="TerritoryAttachment" type="territory">	<option name="production" value="1"/>			</attachment>
 <attachment name="territoryAttachment" attachTo="Lagos-S.Nigeria" 			javaClass="TerritoryAttachment" type="territory">	<option name="production" value="1"/>														</attachment>
 <attachment name="territoryAttachment" attachTo="Lanzhou" 					javaClass="TerritoryAttachment" type="territory">	<option name="production" value="1"/>														</attachment>
@@ -4719,7 +4731,7 @@
 <attachment name="territoryAttachment" attachTo="Latgale" 					javaClass="TerritoryAttachment" type="territory">	<option name="production" value="1"/>														</attachment>
 <attachment name="territoryAttachment" attachTo="Latvia" 					javaClass="TerritoryAttachment" type="territory">	<option name="production" value="1"/>														</attachment>
 <attachment name="territoryAttachment" attachTo="Leeward Is." 				javaClass="TerritoryAttachment" type="territory">	<option name="production" value="1"/>			</attachment>
-<attachment name="territoryAttachment" attachTo="Leningrad" 				javaClass="TerritoryAttachment" type="territory">	<option name="production" value="1"/>				</attachment>
+<attachment name="territoryAttachment" attachTo="Leningrad" 				javaClass="TerritoryAttachment" type="territory">	<option name="production" value="4"/>				</attachment>
 <attachment name="territoryAttachment" attachTo="Leopoldville-Kinshasa" 	javaClass="TerritoryAttachment" type="territory">	<option name="production" value="1"/>														</attachment>
 <attachment name="territoryAttachment" attachTo="Lhasa-E.Tibet" 			javaClass="TerritoryAttachment" type="territory">	<option name="production" value="0"/>		<option name="isImpassable" value="true"/>	</attachment>
 <attachment name="territoryAttachment" attachTo="Liberia" 					javaClass="TerritoryAttachment" type="territory">	<option name="production" value="1"/>														</attachment>
@@ -4733,47 +4745,50 @@
 	 <option name="victoryCity" value="1"/>
 </attachment>
 <attachment name="territoryAttachment" attachTo="Lorestan" 					javaClass="TerritoryAttachment" type="territory">	<option name="production" value="1"/>														</attachment>
-<attachment name="territoryAttachment" attachTo="Lorraine" 					javaClass="TerritoryAttachment" type="territory">	<option name="production" value="1"/>														</attachment>
-<attachment name="territoryAttachment" attachTo="Los Angeles-S.California"	javaClass="TerritoryAttachment" type="territory">	<option name="production" value="1"/>			</attachment>
+<attachment name="territoryAttachment" attachTo="Lorraine" 					javaClass="TerritoryAttachment" type="territory">	<option name="production" value="2"/>														</attachment>
+<attachment name="territoryAttachment" attachTo="Los Angeles-S.California"	javaClass="TerritoryAttachment" type="territory">	<option name="production" value="4"/>			</attachment>
 <attachment name="territoryAttachment" attachTo="Lucknow-Oudh" 				javaClass="TerritoryAttachment" type="territory">	<option name="production" value="1"/>			</attachment>
 <attachment name="territoryAttachment" attachTo="Lviv" 						javaClass="TerritoryAttachment" type="territory">	<option name="production" value="1"/>														</attachment>
 <attachment name="territoryAttachment" attachTo="Madagascar" 				javaClass="TerritoryAttachment" type="territory">	<option name="production" value="1"/>			</attachment>
 <attachment name="territoryAttachment" attachTo="Madeira Is." 				javaClass="TerritoryAttachment" type="territory">	<option name="production" value="1"/>			</attachment>
-<attachment name="territoryAttachment" attachTo="Madras" 					javaClass="TerritoryAttachment" type="territory">	<option name="production" value="1"/>														</attachment>
+<attachment name="territoryAttachment" attachTo="Madras" 					javaClass="TerritoryAttachment" type="territory">	<option name="production" value="2"/>														</attachment>
 <attachment name="territoryAttachment" attachTo="Madrid-Cen.Spain" 			javaClass="TerritoryAttachment" type="territory">	<option name="production" value="1"/>			</attachment>
 <attachment name="territoryAttachment" attachTo="Magadan" 					javaClass="TerritoryAttachment" type="territory">	<option name="production" value="1"/>														</attachment>
 <attachment name="territoryAttachment" attachTo="Majorca" 					javaClass="TerritoryAttachment" type="territory">	<option name="production" value="1"/>														</attachment>
-<attachment name="territoryAttachment" attachTo="Makassar-S.Celebs" 		javaClass="TerritoryAttachment" type="territory">	<option name="production" value="1"/>			</attachment>
-<attachment name="territoryAttachment" attachTo="Malaya" 					javaClass="TerritoryAttachment" type="territory">	<option name="production" value="1"/>			</attachment>
+<attachment name="territoryAttachment" attachTo="Makassar-S.Celebs" 		javaClass="TerritoryAttachment" type="territory">	<option name="production" value="2"/>			</attachment>
+<attachment name="territoryAttachment" attachTo="Malaya" 					javaClass="TerritoryAttachment" type="territory">	<option name="production" value="3"/>			</attachment>
 <attachment name="territoryAttachment" attachTo="Maldives" 					javaClass="TerritoryAttachment" type="territory">	<option name="production" value="1"/>			</attachment>
 <attachment name="territoryAttachment" attachTo="Timbuktu-Mali" 			javaClass="TerritoryAttachment" type="territory">	<option name="production" value="1"/>		</attachment>
 <attachment name="territoryAttachment" attachTo="Malta" 					javaClass="TerritoryAttachment" type="territory">	<option name="production" value="1"/>														</attachment>
 <attachment name="territoryAttachment" attachTo="Manado-N.Celebs" 			javaClass="TerritoryAttachment" type="territory">	<option name="production" value="1"/>			</attachment>
 <attachment name="territoryAttachment" attachTo="W.Nunavut" 					javaClass="TerritoryAttachment" type="territory">	<option name="production" value="1"/>			</attachment>
-<attachment name="territoryAttachment" attachTo="Manchuria-Manchukuo" 		javaClass="TerritoryAttachment" type="territory">	<option name="production" value="1"/>														</attachment>
-<attachment name="territoryAttachment" attachTo="Manila-Luzon" 				javaClass="TerritoryAttachment" type="territory">	<option name="production" value="1"/>				</attachment>
+<attachment name="territoryAttachment" attachTo="Manchuria-Manchukuo" 		javaClass="TerritoryAttachment" type="territory">	
+	<option name="production" value="1"/>	
+	<option name="originalOwner" value="Chinese"/>														
+</attachment>
+<attachment name="territoryAttachment" attachTo="Manila-Luzon" 				javaClass="TerritoryAttachment" type="territory">	<option name="production" value="3"/>				</attachment>
 <attachment name="territoryAttachment" attachTo="Maputo-S.Mozambique" 		javaClass="TerritoryAttachment" type="territory">	<option name="production" value="1"/>														</attachment>
 <attachment name="territoryAttachment" attachTo="Maracaju" 					javaClass="TerritoryAttachment" type="territory">	<option name="production" value="1"/>			</attachment>
-<attachment name="territoryAttachment" attachTo="Mariupol" 					javaClass="TerritoryAttachment" type="territory">	<option name="production" value="1"/>														</attachment>
+<attachment name="territoryAttachment" attachTo="Mariupol" 					javaClass="TerritoryAttachment" type="territory">	<option name="production" value="2"/>														</attachment>
 <attachment name="territoryAttachment" attachTo="Marquesas Is." 			javaClass="TerritoryAttachment" type="territory">	<option name="production" value="1"/>			</attachment>
 <attachment name="territoryAttachment" attachTo="Mato Grosso" 				javaClass="TerritoryAttachment" type="territory">	<option name="production" value="1"/>			</attachment>
 <attachment name="territoryAttachment" attachTo="Mauritania" 				javaClass="TerritoryAttachment" type="territory">	<option name="production" value="1"/>		</attachment>
 <attachment name="territoryAttachment" attachTo="Mazandaran" 				javaClass="TerritoryAttachment" type="territory">	<option name="production" value="1"/>														</attachment>
 <attachment name="territoryAttachment" attachTo="Mecca" 					javaClass="TerritoryAttachment" type="territory">	<option name="production" value="1"/>														</attachment>
-<attachment name="territoryAttachment" attachTo="Meckleburg" 				javaClass="TerritoryAttachment" type="territory">	<option name="production" value="1"/>			</attachment>
-<attachment name="territoryAttachment" attachTo="Medan-W.Sumatra" 			javaClass="TerritoryAttachment" type="territory">	<option name="production" value="1"/>			</attachment>
+<attachment name="territoryAttachment" attachTo="Meckleburg" 				javaClass="TerritoryAttachment" type="territory">	<option name="production" value="3"/>			</attachment>
+<attachment name="territoryAttachment" attachTo="Medan-W.Sumatra" 			javaClass="TerritoryAttachment" type="territory">	<option name="production" value="3"/>			</attachment>
 <attachment name="territoryAttachment" attachTo="Medina-Jeddah" 			javaClass="TerritoryAttachment" type="territory">	<option name="production" value="1"/>														</attachment>
 <attachment name="territoryAttachment" attachTo="Melbourne-Victoria" 		javaClass="TerritoryAttachment" type="territory">	<option name="production" value="1"/>														</attachment>
 <attachment name="territoryAttachment" attachTo="Mexico City" 				javaClass="TerritoryAttachment" type="territory">	<option name="production" value="1"/>		</attachment>
-<attachment name="territoryAttachment" attachTo="Michigan-Indiana" 			javaClass="TerritoryAttachment" type="territory">	<option name="production" value="1"/>														</attachment>
-<attachment name="territoryAttachment" attachTo="Midway Is." 				javaClass="TerritoryAttachment" type="territory">	<option name="production" value="1"/>			</attachment>
+<attachment name="territoryAttachment" attachTo="Michigan-Indiana" 			javaClass="TerritoryAttachment" type="territory">	<option name="production" value="3"/>														</attachment>
+<attachment name="territoryAttachment" attachTo="Midway Is." 				javaClass="TerritoryAttachment" type="territory">	<option name="production" value="3"/>			</attachment>
 <attachment name="territoryAttachment" attachTo="Milan-N.Italy" 			javaClass="TerritoryAttachment" type="territory">	<option name="production" value="1"/>			</attachment>
-<attachment name="territoryAttachment" attachTo="Minsk" 					javaClass="TerritoryAttachment" type="territory">	<option name="production" value="1"/>														</attachment>
-<attachment name="territoryAttachment" attachTo="Mobile-Alabama" 			javaClass="TerritoryAttachment" type="territory">	<option name="production" value="1"/>														</attachment>
+<attachment name="territoryAttachment" attachTo="Minsk" 					javaClass="TerritoryAttachment" type="territory">	<option name="production" value="2"/>														</attachment>
+<attachment name="territoryAttachment" attachTo="Mobile-Alabama" 			javaClass="TerritoryAttachment" type="territory">	<option name="production" value="3"/>														</attachment>
 <attachment name="territoryAttachment" attachTo="Mogadishu" 				javaClass="TerritoryAttachment" type="territory">	<option name="production" value="1"/>														</attachment>
 <attachment name="territoryAttachment" attachTo="Mogilev" 					javaClass="TerritoryAttachment" type="territory">	<option name="production" value="1"/>														</attachment>
 <attachment name="territoryAttachment" attachTo="Moldavia" 					javaClass="TerritoryAttachment" type="territory">	<option name="production" value="1"/>														</attachment>
-<attachment name="territoryAttachment" attachTo="Montana" 					javaClass="TerritoryAttachment" type="territory">	<option name="production" value="1"/>			</attachment>
+<attachment name="territoryAttachment" attachTo="Montana" 					javaClass="TerritoryAttachment" type="territory">	<option name="production" value="3"/>			</attachment>
 <attachment name="territoryAttachment" attachTo="Montenegro" 				javaClass="TerritoryAttachment" type="territory">	<option name="production" value="1"/>		</attachment>
 <attachment name="territoryAttachment" attachTo="Monterrey" 				javaClass="TerritoryAttachment" type="territory">	<option name="production" value="1"/>														</attachment>
 <attachment name="territoryAttachment" attachTo="Morocco" 					javaClass="TerritoryAttachment" type="territory">	<option name="production" value="1"/>														</attachment>
@@ -4784,13 +4799,16 @@
 </attachment>
 <attachment name="territoryAttachment" attachTo="Mosul-Kirkuk" 				javaClass="TerritoryAttachment" type="territory">	<option name="production" value="1"/>													</attachment>
 <attachment name="territoryAttachment" attachTo="Mozhaysk-Kaluga" 			javaClass="TerritoryAttachment" type="territory">	<option name="production" value="1"/>														</attachment>
-<attachment name="territoryAttachment" attachTo="Mukden-Port Arthur" 		javaClass="TerritoryAttachment" type="territory">	<option name="production" value="1"/>														</attachment>
+<attachment name="territoryAttachment" attachTo="Mukden-Port Arthur" 		javaClass="TerritoryAttachment" type="territory">	
+	<option name="production" value="3"/>	
+	<option name="originalOwner" value="Chinese"/>														
+</attachment>
 <attachment name="territoryAttachment" attachTo="Murmansk" 					javaClass="TerritoryAttachment" type="territory">	<option name="production" value="1"/>			</attachment>
 <attachment name="territoryAttachment" attachTo="Muscat" 					javaClass="TerritoryAttachment" type="territory">	<option name="production" value="1"/>														</attachment>
 <attachment name="territoryAttachment" attachTo="N.Burma" 					javaClass="TerritoryAttachment" type="territory">	<option name="production" value="1"/>		</attachment>
 <attachment name="territoryAttachment" attachTo="N.England" 				javaClass="TerritoryAttachment" type="territory">	<option name="production" value="1"/>														</attachment>
 <attachment name="territoryAttachment" attachTo="N.Ireland" 				javaClass="TerritoryAttachment" type="territory">	<option name="production" value="1"/>														</attachment>
-<attachment name="territoryAttachment" attachTo="N.Korea-Chosen" 			javaClass="TerritoryAttachment" type="territory">	<option name="production" value="1"/>			</attachment>
+<attachment name="territoryAttachment" attachTo="N.Korea-Chosen" 			javaClass="TerritoryAttachment" type="territory">	<option name="production" value="2"/>			</attachment>
 <attachment name="territoryAttachment" attachTo="N.Nigeria" 				javaClass="TerritoryAttachment" type="territory">	<option name="production" value="1"/>														</attachment>
 <attachment name="territoryAttachment" attachTo="N.Ontario" 				javaClass="TerritoryAttachment" type="territory">	<option name="production" value="1"/>			</attachment>
 <attachment name="territoryAttachment" attachTo="N.Quebec" 					javaClass="TerritoryAttachment" type="territory">	<option name="production" value="1"/>			</attachment>
@@ -4799,80 +4817,86 @@
 <attachment name="territoryAttachment" attachTo="Nafud" 					javaClass="TerritoryAttachment" type="territory">	<option name="production" value="1"/>														</attachment>
 <attachment name="territoryAttachment" attachTo="Nagpur" 					javaClass="TerritoryAttachment" type="territory">	<option name="production" value="1"/>			</attachment>
 <attachment name="territoryAttachment" attachTo="Nunavut" 					javaClass="TerritoryAttachment" type="territory">	<option name="production" value="1"/>			</attachment>
-<attachment name="territoryAttachment" attachTo="Nanking" 					javaClass="TerritoryAttachment" type="territory">	<option name="production" value="1"/>														</attachment>
+<attachment name="territoryAttachment" attachTo="Nanking" 					javaClass="TerritoryAttachment" type="territory">	
+	<option name="production" value="3"/>														
+	<option name="originalOwner" value="Chinese"/>	
+</attachment>
 <attachment name="territoryAttachment" attachTo="Naples-S.Italy" 			javaClass="TerritoryAttachment" type="territory">	<option name="production" value="1"/>			</attachment>
 <attachment name="territoryAttachment" attachTo="Narvik" 					javaClass="TerritoryAttachment" type="territory">	<option name="production" value="1"/>		</attachment>
 <attachment name="territoryAttachment" attachTo="Natal" 					javaClass="TerritoryAttachment" type="territory">	<option name="production" value="1"/>														</attachment>
 <attachment name="territoryAttachment" attachTo="Navarre" 					javaClass="TerritoryAttachment" type="territory">	<option name="production" value="1"/>		</attachment>
-<attachment name="territoryAttachment" attachTo="Nebraska" 					javaClass="TerritoryAttachment" type="territory">	<option name="production" value="1"/>														</attachment>
+<attachment name="territoryAttachment" attachTo="Nebraska" 					javaClass="TerritoryAttachment" type="territory">	<option name="production" value="3"/>														</attachment>
 <attachment name="territoryAttachment" attachTo="Nejd" 						javaClass="TerritoryAttachment" type="territory">	<option name="production" value="1"/>			</attachment>
 <attachment name="territoryAttachment" attachTo="Nenetsia" 					javaClass="TerritoryAttachment" type="territory">	<option name="production" value="1"/>			</attachment>
 <attachment name="territoryAttachment" attachTo="Nepal" 					javaClass="TerritoryAttachment" type="territory">	<option name="production" value="1"/>		</attachment>
-<attachment name="territoryAttachment" attachTo="Netherlands" 				javaClass="TerritoryAttachment" type="territory">	<option name="production" value="1"/>			</attachment>
-<attachment name="territoryAttachment" attachTo="Nevada" 					javaClass="TerritoryAttachment" type="territory">	<option name="production" value="1"/>			</attachment>
+<attachment name="territoryAttachment" attachTo="Netherlands" 				javaClass="TerritoryAttachment" type="territory">	<option name="production" value="2"/>			</attachment>
+<attachment name="territoryAttachment" attachTo="Nevada" 					javaClass="TerritoryAttachment" type="territory">	<option name="production" value="3"/>			</attachment>
 <attachment name="territoryAttachment" attachTo="S.Quebec" 			javaClass="TerritoryAttachment" type="territory">	<option name="production" value="1"/>			</attachment>
 <attachment name="territoryAttachment" attachTo="New Caledonia Is." 		javaClass="TerritoryAttachment" type="territory">	<option name="production" value="1"/>			</attachment>
-<attachment name="territoryAttachment" attachTo="New Delhi" 				javaClass="TerritoryAttachment" type="territory">	<option name="production" value="1"/>			</attachment>
+<attachment name="territoryAttachment" attachTo="New Delhi" 				javaClass="TerritoryAttachment" type="territory">	<option name="production" value="3"/>				<option name="capital" value="UK_Pacific"/>	
+	</attachment>
 <attachment name="territoryAttachment" attachTo="New Hebrides Is." 			javaClass="TerritoryAttachment" type="territory">	<option name="production" value="1"/>			</attachment>
-<attachment name="territoryAttachment" attachTo="New Orleans-Louisiana" 	javaClass="TerritoryAttachment" type="territory">	<option name="production" value="1"/>			</attachment>
-<attachment name="territoryAttachment" attachTo="New York-New Jersey" 		javaClass="TerritoryAttachment" type="territory">	<option name="production" value="1"/>			</attachment>
+<attachment name="territoryAttachment" attachTo="New Orleans-Louisiana" 	javaClass="TerritoryAttachment" type="territory">	<option name="production" value="3"/>			</attachment>
+<attachment name="territoryAttachment" attachTo="New York-New Jersey" 		javaClass="TerritoryAttachment" type="territory">	<option name="production" value="5"/>			</attachment>
 <attachment name="territoryAttachment" attachTo="Niamey" 					javaClass="TerritoryAttachment" type="territory">	<option name="production" value="1"/>		</attachment>
 <attachment name="territoryAttachment" attachTo="Nicaragua" 				javaClass="TerritoryAttachment" type="territory">	<option name="production" value="1"/>			</attachment>
-<attachment name="territoryAttachment" attachTo="Nizhny Novgorod" 			javaClass="TerritoryAttachment" type="territory">	<option name="production" value="1"/>														</attachment>
+<attachment name="territoryAttachment" attachTo="Nizhny Novgorod" 			javaClass="TerritoryAttachment" type="territory">	<option name="production" value="2"/>														</attachment>
 <attachment name="territoryAttachment" attachTo="Nome" 						javaClass="TerritoryAttachment" type="territory">	<option name="production" value="1"/>			</attachment>
-<attachment name="territoryAttachment" attachTo="Normandy" 					javaClass="TerritoryAttachment" type="territory">	<option name="production" value="1"/>													</attachment>
+<attachment name="territoryAttachment" attachTo="Normandy" 					javaClass="TerritoryAttachment" type="territory">	<option name="production" value="2"/>													</attachment>
 <attachment name="territoryAttachment" attachTo="Norrland" 					javaClass="TerritoryAttachment" type="territory">	<option name="production" value="1"/>		</attachment>
 <attachment name="territoryAttachment" attachTo="Norte" 					javaClass="TerritoryAttachment" type="territory">	<option name="production" value="1"/>														</attachment>
 <attachment name="territoryAttachment" attachTo="Northwest Territories" 	javaClass="TerritoryAttachment" type="territory">	<option name="production" value="1"/>			</attachment>
 <attachment name="territoryAttachment" attachTo="Novgorod" 					javaClass="TerritoryAttachment" type="territory">	<option name="production" value="1"/>														</attachment>
-<attachment name="territoryAttachment" attachTo="Novosibirsk" 				javaClass="TerritoryAttachment" type="territory">	<option name="production" value="1"/>														</attachment>
-<attachment name="territoryAttachment" attachTo="Odesa-Mykoliav" 			javaClass="TerritoryAttachment" type="territory">	<option name="production" value="1"/>														</attachment>
+<attachment name="territoryAttachment" attachTo="Novosibirsk" 				javaClass="TerritoryAttachment" type="territory">	<option name="production" value="3"/>														</attachment>
+<attachment name="territoryAttachment" attachTo="Odesa-Mykoliav" 			javaClass="TerritoryAttachment" type="territory">	<option name="production" value="2"/>														</attachment>
 <attachment name="territoryAttachment" attachTo="Ogoden" 					javaClass="TerritoryAttachment" type="territory">	<option name="production" value="1"/>														</attachment>
-<attachment name="territoryAttachment" attachTo="Ohio" 						javaClass="TerritoryAttachment" type="territory">	<option name="production" value="1"/>			</attachment>
-<attachment name="territoryAttachment" attachTo="Okinawa-Ryukyu Is." 		javaClass="TerritoryAttachment" type="territory">	<option name="production" value="1"/>			</attachment>
+<attachment name="territoryAttachment" attachTo="Ohio" 						javaClass="TerritoryAttachment" type="territory">	<option name="production" value="3"/>			</attachment>
+<attachment name="territoryAttachment" attachTo="Okinawa-Ryukyu Is." 		javaClass="TerritoryAttachment" type="territory">	<option name="production" value="3"/>			</attachment>
 <attachment name="territoryAttachment" attachTo="Olgiy" 					javaClass="TerritoryAttachment" type="territory">	<option name="production" value="1"/>														</attachment>
 <attachment name="territoryAttachment" attachTo="Oman" 						javaClass="TerritoryAttachment" type="territory">	<option name="production" value="1"/>														</attachment>
 <attachment name="territoryAttachment" attachTo="Omsk" 						javaClass="TerritoryAttachment" type="territory">	<option name="production" value="1"/>		</attachment>
 <attachment name="territoryAttachment" attachTo="Oran" 						javaClass="TerritoryAttachment" type="territory">	<option name="production" value="1"/>														</attachment>
 <attachment name="territoryAttachment" attachTo="Orissa" 					javaClass="TerritoryAttachment" type="territory">	<option name="production" value="1"/>														</attachment>
-<attachment name="territoryAttachment" attachTo="Orleans" 					javaClass="TerritoryAttachment" type="territory">	<option name="production" value="1"/>														</attachment>
-<attachment name="territoryAttachment" attachTo="Oslo" 						javaClass="TerritoryAttachment" type="territory">	<option name="production" value="1"/>			</attachment>
+<attachment name="territoryAttachment" attachTo="Orleans" 					javaClass="TerritoryAttachment" type="territory">	<option name="production" value="3"/>														</attachment>
+<attachment name="territoryAttachment" attachTo="Oslo" 						javaClass="TerritoryAttachment" type="territory">	<option name="production" value="2"/>			</attachment>
 <attachment name="territoryAttachment" attachTo="Ottawa-Montreal" 			javaClass="TerritoryAttachment" type="territory">	<option name="production" value="1"/>			</attachment>
 <attachment name="territoryAttachment" attachTo="Ouargla" 					javaClass="TerritoryAttachment" type="territory">	<option name="production" value="1"/>			</attachment>
 <attachment name="territoryAttachment" attachTo="Palawan" 					javaClass="TerritoryAttachment" type="territory">	<option name="production" value="1"/>			</attachment>
-<attachment name="territoryAttachment" attachTo="Palembang-S.Sumatra" 		javaClass="TerritoryAttachment" type="territory">	<option name="production" value="1"/>			</attachment>
+<attachment name="territoryAttachment" attachTo="Palembang-S.Sumatra" 		javaClass="TerritoryAttachment" type="territory">	<option name="production" value="3"/>			</attachment>
 <attachment name="territoryAttachment" attachTo="Palestine" 				javaClass="TerritoryAttachment" type="territory">	<option name="production" value="1"/>			</attachment>
 <attachment name="territoryAttachment" attachTo="Palmyra Atoll" 			javaClass="TerritoryAttachment" type="territory">	<option name="production" value="1"/>			</attachment>
 <attachment name="territoryAttachment" attachTo="Pampas" 					javaClass="TerritoryAttachment" type="territory">	<option name="production" value="1"/>														</attachment>
-<attachment name="territoryAttachment" attachTo="Panama" 					javaClass="TerritoryAttachment" type="territory">	<option name="production" value="1"/>				</attachment>
-<attachment name="territoryAttachment" attachTo="Panay Leyte-Visayas Is."	javaClass="TerritoryAttachment" type="territory">	<option name="production" value="1"/>			</attachment>
+<attachment name="territoryAttachment" attachTo="Panama" 					javaClass="TerritoryAttachment" type="territory">	<option name="production" value="2"/>				</attachment>
+<attachment name="territoryAttachment" attachTo="Panay Leyte-Visayas Is."	javaClass="TerritoryAttachment" type="territory">	<option name="production" value="2"/>			</attachment>
 <attachment name="territoryAttachment" attachTo="Paraguay" 					javaClass="TerritoryAttachment" type="territory">	<option name="production" value="1"/>														</attachment>
 <attachment name="territoryAttachment" attachTo="Paris" 			javaClass="TerritoryAttachment" type="territory">
-         <option name="production" value="1"/>
+         <option name="production" value="5"/>
          <option name="capital" value="French"/>
 	 <option name="victoryCity" value="1"/>
-	 <option name="originalOwner" value="French"/>
 </attachment>
 <attachment name="territoryAttachment" attachTo="Patagonia" 				javaClass="TerritoryAttachment" type="territory">	<option name="production" value="1"/>														</attachment>
-<attachment name="territoryAttachment" attachTo="Peking-Tientsin" 			javaClass="TerritoryAttachment" type="territory">	<option name="production" value="1"/>														</attachment>
+<attachment name="territoryAttachment" attachTo="Peking-Tientsin" 			javaClass="TerritoryAttachment" type="territory">	
+	<option name="production" value="2"/>	
+	<option name="originalOwner" value="Chinese"/>														
+</attachment>
 <attachment name="territoryAttachment" attachTo="Pelelui-Palau Is." 		javaClass="TerritoryAttachment" type="territory">	<option name="production" value="1"/>			</attachment>
 <attachment name="territoryAttachment" attachTo="Peleponnese" 				javaClass="TerritoryAttachment" type="territory">	<option name="production" value="1"/>		</attachment>
-<attachment name="territoryAttachment" attachTo="Perm" 						javaClass="TerritoryAttachment" type="territory">	<option name="production" value="1"/>		</attachment>
+<attachment name="territoryAttachment" attachTo="Perm" 						javaClass="TerritoryAttachment" type="territory">	<option name="production" value="2"/>		</attachment>
 <attachment name="territoryAttachment" attachTo="Perth-W.Australia" 		javaClass="TerritoryAttachment" type="territory">	<option name="production" value="1"/>														</attachment>
 <attachment name="territoryAttachment" attachTo="Peru" 						javaClass="TerritoryAttachment" type="territory">	<option name="production" value="1"/>		</attachment>
 <attachment name="territoryAttachment" attachTo="Phoenix Is." 				javaClass="TerritoryAttachment" type="territory">	<option name="production" value="1"/>			</attachment>
 <attachment name="territoryAttachment" attachTo="Ploiesti-E.Romania" 		javaClass="TerritoryAttachment" type="territory">	<option name="production" value="1"/>			 </attachment>
-<attachment name="territoryAttachment" attachTo="Poitou" 					javaClass="TerritoryAttachment" type="territory">	<option name="production" value="1"/>														</attachment>
-<attachment name="territoryAttachment" attachTo="Pomerania" 				javaClass="TerritoryAttachment" type="territory">	<option name="production" value="1"/>			</attachment>
+<attachment name="territoryAttachment" attachTo="Poitou" 					javaClass="TerritoryAttachment" type="territory">	<option name="production" value="2"/>														</attachment>
+<attachment name="territoryAttachment" attachTo="Pomerania" 				javaClass="TerritoryAttachment" type="territory">	<option name="production" value="2"/>			</attachment>
 <attachment name="territoryAttachment" attachTo="Port Au Prince-Haiti" 		javaClass="TerritoryAttachment" type="territory">	<option name="production" value="1"/>			</attachment>
-<attachment name="territoryAttachment" attachTo="Port Moresby-Papua" 		javaClass="TerritoryAttachment" type="territory">	<option name="production" value="1"/>			</attachment>
-<attachment name="territoryAttachment" attachTo="Portland-Oregon" 			javaClass="TerritoryAttachment" type="territory">	<option name="production" value="1"/>			</attachment>
+<attachment name="territoryAttachment" attachTo="Port Moresby-Papua" 		javaClass="TerritoryAttachment" type="territory">	<option name="production" value="3"/>			</attachment>
+<attachment name="territoryAttachment" attachTo="Portland-Oregon" 			javaClass="TerritoryAttachment" type="territory">	<option name="production" value="3"/>			</attachment>
 <attachment name="territoryAttachment" attachTo="Portuguese Guinea" 		javaClass="TerritoryAttachment" type="territory">	<option name="production" value="1"/>			</attachment>
 <attachment name="territoryAttachment" attachTo="Praetoria" 				javaClass="TerritoryAttachment" type="territory">	<option name="production" value="1"/>														</attachment>
-<attachment name="territoryAttachment" attachTo="Prague-Bohemia Moravia" 	javaClass="TerritoryAttachment" type="territory">	<option name="production" value="1"/>			</attachment>
+<attachment name="territoryAttachment" attachTo="Prague-Bohemia Moravia" 	javaClass="TerritoryAttachment" type="territory">	<option name="production" value="2"/>			</attachment>
 <attachment name="territoryAttachment" attachTo="Primorsky" 				javaClass="TerritoryAttachment" type="territory">	<option name="production" value="1"/>														</attachment>
 <attachment name="territoryAttachment" attachTo="Prinsk" 					javaClass="TerritoryAttachment" type="territory">	<option name="production" value="1"/>														</attachment>
-<attachment name="territoryAttachment" attachTo="Provence-Marseille" 		javaClass="TerritoryAttachment" type="territory">	<option name="production" value="1"/>		</attachment>
+<attachment name="territoryAttachment" attachTo="Provence-Marseille" 		javaClass="TerritoryAttachment" type="territory">	<option name="production" value="2"/>		</attachment>
 <attachment name="territoryAttachment" attachTo="Prypriat" 					javaClass="TerritoryAttachment" type="territory">	<option name="production" value="0"/>			</attachment>
 <attachment name="territoryAttachment" attachTo="Pskov" 					javaClass="TerritoryAttachment" type="territory">	<option name="production" value="1"/>														</attachment>
 <attachment name="territoryAttachment" attachTo="Punjab" 					javaClass="TerritoryAttachment" type="territory">	<option name="production" value="1"/>														</attachment>
@@ -4887,40 +4911,46 @@
 <attachment name="territoryAttachment" attachTo="Rio Grande Du Sol" 		javaClass="TerritoryAttachment" type="territory">	<option name="production" value="1"/>														</attachment>
 <attachment name="territoryAttachment" attachTo="Riyadh" 					javaClass="TerritoryAttachment" type="territory">	<option name="production" value="1"/>														</attachment>
 <attachment name="territoryAttachment" attachTo="Rome-Cen.Italy" 			javaClass="TerritoryAttachment" type="territory">
-         <option name="production" value="6"/>			
+         <option name="production" value="5"/>			
          <option name="capital" value="Italians"/>
 	 <option name="victoryCity" value="1"/>
 </attachment>
-<attachment name="territoryAttachment" attachTo="Rostov" 					javaClass="TerritoryAttachment" type="territory">	<option name="production" value="1"/>													</attachment>
+<attachment name="territoryAttachment" attachTo="Rostov" 					javaClass="TerritoryAttachment" type="territory">	<option name="production" value="2"/>													</attachment>
 <attachment name="territoryAttachment" attachTo="Rub Al Kali" 				javaClass="TerritoryAttachment" type="territory">	<option name="production" value="1"/>														</attachment>
 <attachment name="territoryAttachment" attachTo="Ryazan" 					javaClass="TerritoryAttachment" type="territory">	<option name="production" value="1"/>														</attachment>
 <attachment name="territoryAttachment" attachTo="Rzesow" 					javaClass="TerritoryAttachment" type="territory">	<option name="production" value="1"/>														</attachment>
 <attachment name="territoryAttachment" attachTo="Rzhev" 					javaClass="TerritoryAttachment" type="territory">	<option name="production" value="1"/>														</attachment>
 <attachment name="territoryAttachment" attachTo="S.Hijaz" 					javaClass="TerritoryAttachment" type="territory">	<option name="production" value="1"/>														</attachment>
-<attachment name="territoryAttachment" attachTo="S.Korea-Chosen" 			javaClass="TerritoryAttachment" type="territory">	<option name="production" value="1"/>			</attachment>
+<attachment name="territoryAttachment" attachTo="S.Korea-Chosen" 			javaClass="TerritoryAttachment" type="territory">	<option name="production" value="3"/>			</attachment>
 <attachment name="territoryAttachment" attachTo="S.Rhodesia" 				javaClass="TerritoryAttachment" type="territory">	<option name="production" value="1"/>														</attachment>
 <attachment name="territoryAttachment" attachTo="S.Sakhalin" 				javaClass="TerritoryAttachment" type="territory">	<option name="production" value="1"/>		</attachment>
-<attachment name="territoryAttachment" attachTo="Sacramento-N.California"	javaClass="TerritoryAttachment" type="territory">	<option name="production" value="1"/>			</attachment>
-<attachment name="territoryAttachment" attachTo="Saigon-Cochinchina" 		javaClass="TerritoryAttachment" type="territory">	<option name="production" value="1"/>			</attachment>
+<attachment name="territoryAttachment" attachTo="Sacramento-N.California"	javaClass="TerritoryAttachment" type="territory">	<option name="production" value="3"/>			</attachment>
+<attachment name="territoryAttachment" attachTo="Saigon-Cochinchina" 		javaClass="TerritoryAttachment" type="territory">	<option name="production" value="2"/>			</attachment>
 <attachment name="territoryAttachment" attachTo="Saipan-Mariana Is." 		javaClass="TerritoryAttachment" type="territory">	<option name="production" value="1"/>			</attachment>
 <attachment name="territoryAttachment" attachTo="Sakha" 					javaClass="TerritoryAttachment" type="territory">	<option name="production" value="1"/>			</attachment>
-<attachment name="territoryAttachment" attachTo="Salamaua Lae-New Guinea"	javaClass="TerritoryAttachment" type="territory">	<option name="production" value="1"/>			</attachment>
+<attachment name="territoryAttachment" attachTo="Salamaua Lae-New Guinea"	javaClass="TerritoryAttachment" type="territory">	<option name="production" value="2"/>			</attachment>
 <attachment name="territoryAttachment" attachTo="Samoan Is." 				javaClass="TerritoryAttachment" type="territory">	<option name="production" value="1"/>			</attachment>
-<attachment name="territoryAttachment" attachTo="San Francisco-Cen.California" javaClass="TerritoryAttachment" type="territory">	<option name="production" value="1"/>				</attachment>">
+<attachment name="territoryAttachment" attachTo="San Francisco-Cen.California" javaClass="TerritoryAttachment" type="territory">	<option name="production" value="5"/>				</attachment>">
 <attachment name="territoryAttachment" attachTo="San Juan-Puerto Rico" 		javaClass="TerritoryAttachment" type="territory">	<option name="production" value="1"/>			</attachment>
 <attachment name="territoryAttachment" attachTo="Sansapor-Vogelkop Pen." 	javaClass="TerritoryAttachment" type="territory">	<option name="production" value="1"/>			</attachment>
-<attachment name="territoryAttachment" attachTo="Santiago-Guantanamo" 		javaClass="TerritoryAttachment" type="territory">	<option name="production" value="1"/>			</attachment>
+<attachment name="territoryAttachment" attachTo="Santiago-Guantanamo" 		javaClass="TerritoryAttachment" type="territory">	<option name="production" value="2"/>			</attachment>
 <attachment name="territoryAttachment" attachTo="Santo Domingo-Domenica" 	javaClass="TerritoryAttachment" type="territory">	<option name="production" value="1"/>			</attachment>
 <attachment name="territoryAttachment" attachTo="Sarajevo-Bosnia" 			javaClass="TerritoryAttachment" type="territory">	<option name="production" value="1"/>		</attachment>
-<attachment name="territoryAttachment" attachTo="Sarawak-N.Borneo" 			javaClass="TerritoryAttachment" type="territory">	<option name="production" value="1"/>			</attachment>
+<attachment name="territoryAttachment" attachTo="Sarawak-N.Borneo" 			javaClass="TerritoryAttachment" type="territory">	<option name="production" value="2"/>			</attachment>
 <attachment name="territoryAttachment" attachTo="Sardinia" 					javaClass="TerritoryAttachment" type="territory">	<option name="production" value="1"/>			</attachment>
 <attachment name="territoryAttachment" attachTo="Savo-Ostrobothnia" 		javaClass="TerritoryAttachment" type="territory">	<option name="production" value="1"/>			</attachment>
-<attachment name="territoryAttachment" attachTo="Schleswig-Holstein" 		javaClass="TerritoryAttachment" type="territory">	<option name="production" value="1"/>														</attachment>
+<attachment name="territoryAttachment" attachTo="Schleswig-Holstein" 		javaClass="TerritoryAttachment" type="territory">	<option name="production" value="3"/>														</attachment>
 <attachment name="territoryAttachment" attachTo="Scotland" 					javaClass="TerritoryAttachment" type="territory">	<option name="production" value="1"/>		</attachment>
-<attachment name="territoryAttachment" attachTo="Seattle-Washington" 		javaClass="TerritoryAttachment" type="territory">	<option name="production" value="1"/>			</attachment>
+<attachment name="territoryAttachment" attachTo="Seattle-Washington" 		javaClass="TerritoryAttachment" type="territory">	<option name="production" value="3"/>			</attachment>
 <attachment name="territoryAttachment" attachTo="Seychelles" 				javaClass="TerritoryAttachment" type="territory">	<option name="production" value="1"/>			</attachment>
-<attachment name="territoryAttachment" attachTo="Shanghai-Kiangsu" 			javaClass="TerritoryAttachment" type="territory">	<option name="production" value="1"/>															</attachment>
-<attachment name="territoryAttachment" attachTo="Shangtung" 				javaClass="TerritoryAttachment" type="territory">	<option name="production" value="1"/>														</attachment>
+<attachment name="territoryAttachment" attachTo="Shanghai-Kiangsu" 			javaClass="TerritoryAttachment" type="territory">	
+	<option name="production" value="3"/>	
+	<option name="originalOwner" value="Chinese"/>															
+</attachment>
+<attachment name="territoryAttachment" attachTo="Shangtung" javaClass="TerritoryAttachment" type="territory">	
+	<option name="production" value="2"/>														
+	<option name="originalOwner" value="Chinese"/>	
+</attachment>
 <attachment name="territoryAttachment" attachTo="Shensi" 					javaClass="TerritoryAttachment" type="territory">	<option name="production" value="1"/>														</attachment>
 <attachment name="territoryAttachment" attachTo="Shetland Is." 				javaClass="TerritoryAttachment" type="territory">	<option name="production" value="1"/>														</attachment>
 <attachment name="territoryAttachment" attachTo="Shikoku" 					javaClass="TerritoryAttachment" type="territory">	<option name="production" value="1"/>		</attachment>
@@ -4931,26 +4961,26 @@
 <attachment name="territoryAttachment" attachTo="Silesia" 					javaClass="TerritoryAttachment" type="territory">	<option name="production" value="1"/>														</attachment>
 <attachment name="territoryAttachment" attachTo="Sinai" 					javaClass="TerritoryAttachment" type="territory">	<option name="production" value="1"/>			</attachment>
 <attachment name="territoryAttachment" attachTo="Sinaloa-Guadalajara" 		javaClass="TerritoryAttachment" type="territory">	<option name="production" value="1"/>			</attachment>
-<attachment name="territoryAttachment" attachTo="Singapore-Malacca" 		javaClass="TerritoryAttachment" type="territory">	<option name="production" value="1"/>			</attachment>
+<attachment name="territoryAttachment" attachTo="Singapore-Malacca" 		javaClass="TerritoryAttachment" type="territory">	<option name="production" value="4"/>			</attachment>
 <attachment name="territoryAttachment" attachTo="Sinkiang" 					javaClass="TerritoryAttachment" type="territory">	<option name="production" value="1"/>														</attachment>
 <attachment name="territoryAttachment" attachTo="Sistan-Baluchestan" 		javaClass="TerritoryAttachment" type="territory">	<option name="production" value="1"/>														</attachment>
 <attachment name="territoryAttachment" attachTo="Sitka" 					javaClass="TerritoryAttachment" type="territory">	<option name="production" value="1"/>			</attachment>
 <attachment name="territoryAttachment" attachTo="Siuyuyan" 					javaClass="TerritoryAttachment" type="territory">	<option name="production" value="1"/>			</attachment>
 <attachment name="territoryAttachment" attachTo="Slovakia" 					javaClass="TerritoryAttachment" type="territory">	<option name="production" value="1"/>		</attachment>
 <attachment name="territoryAttachment" attachTo="Slovenia-N.Croatia" 		javaClass="TerritoryAttachment" type="territory">	<option name="production" value="1"/>			</attachment>
-<attachment name="territoryAttachment" attachTo="Smolensk" 					javaClass="TerritoryAttachment" type="territory">	<option name="production" value="1"/>														</attachment>
+<attachment name="territoryAttachment" attachTo="Smolensk" 					javaClass="TerritoryAttachment" type="territory">	<option name="production" value="3"/>														</attachment>
 <attachment name="territoryAttachment" attachTo="Smyrna" 					javaClass="TerritoryAttachment" type="territory">	<option name="production" value="1"/>														</attachment>
 <attachment name="territoryAttachment" attachTo="Society Is." 				javaClass="TerritoryAttachment" type="territory">	<option name="production" value="1"/>			</attachment>
 <attachment name="territoryAttachment" attachTo="Socotra" 					javaClass="TerritoryAttachment" type="territory">	<option name="production" value="1"/>														</attachment>
-<attachment name="territoryAttachment" attachTo="Sofia-W.Bulgaria" 			javaClass="TerritoryAttachment" type="territory">	<option name="production" value="1"/>			</attachment>
+<attachment name="territoryAttachment" attachTo="Sofia-W.Bulgaria" 			javaClass="TerritoryAttachment" type="territory">	<option name="production" value="2"/>			</attachment>
 <attachment name="territoryAttachment" attachTo="Southwest Africa" 			javaClass="TerritoryAttachment" type="territory">	<option name="production" value="1"/>														</attachment>
 <attachment name="territoryAttachment" attachTo="Spanish Gabon" 			javaClass="TerritoryAttachment" type="territory">	<option name="production" value="1"/>			</attachment>
 <attachment name="territoryAttachment" attachTo="St.Johns-Newfoundland" 	javaClass="TerritoryAttachment" type="territory">	<option name="production" value="1"/>			</attachment>
-<attachment name="territoryAttachment" attachTo="St.Louis-Arkansas" 		javaClass="TerritoryAttachment" type="territory">	<option name="production" value="1"/>														</attachment>
-<attachment name="territoryAttachment" attachTo="Stalingrad-Volga" 			javaClass="TerritoryAttachment" type="territory">	<option name="production" value="1"/>				</attachment>
+<attachment name="territoryAttachment" attachTo="St.Louis-Arkansas" 		javaClass="TerritoryAttachment" type="territory">	<option name="production" value="3"/>														</attachment>
+<attachment name="territoryAttachment" attachTo="Stalingrad-Volga" 			javaClass="TerritoryAttachment" type="territory">	<option name="production" value="4"/>				</attachment>
 <attachment name="territoryAttachment" attachTo="Stavropol" 				javaClass="TerritoryAttachment" type="territory">	<option name="production" value="1"/>														</attachment>
-<attachment name="territoryAttachment" attachTo="Stockholm" 				javaClass="TerritoryAttachment" type="territory">	<option name="production" value="1"/>		</attachment>
-<attachment name="territoryAttachment" attachTo="Surabaya-E.Java" 			javaClass="TerritoryAttachment" type="territory">	<option name="production" value="1"/>			</attachment>
+<attachment name="territoryAttachment" attachTo="Stockholm" 				javaClass="TerritoryAttachment" type="territory">	<option name="production" value="3"/>		</attachment>
+<attachment name="territoryAttachment" attachTo="Surabaya-E.Java" 			javaClass="TerritoryAttachment" type="territory">	<option name="production" value="2"/>			</attachment>
 <attachment name="territoryAttachment" attachTo="Svalbard" 					javaClass="TerritoryAttachment" type="territory">	<option name="production" value="1"/>			</attachment>
 <attachment name="territoryAttachment" attachTo="Svealand" 					javaClass="TerritoryAttachment" type="territory">	<option name="production" value="1"/>		</attachment>
 <attachment name="territoryAttachment" attachTo="Switzerland" 				javaClass="TerritoryAttachment" type="territory">	<option name="production" value="0"/>		<option name="isImpassable" value="true"/>	</attachment>
@@ -4959,25 +4989,25 @@
   <option name="capital" value="ANZAC"/>
   <option name="victoryCity" value="1"/>
 </attachment>
-<attachment name="territoryAttachment" attachTo="Taipei-Formosa" 			javaClass="TerritoryAttachment" type="territory">	<option name="production" value="1"/>														</attachment>
+<attachment name="territoryAttachment" attachTo="Taipei-Formosa" 			javaClass="TerritoryAttachment" type="territory">	<option name="production" value="2"/>														</attachment>
 <attachment name="territoryAttachment" attachTo="Tanganyika" 				javaClass="TerritoryAttachment" type="territory">	<option name="production" value="1"/>														</attachment>
 <attachment name="territoryAttachment" attachTo="Tangier" 					javaClass="TerritoryAttachment" type="territory">	<option name="production" value="1"/>														</attachment>
 <attachment name="territoryAttachment" attachTo="Tanimbar Is." 				javaClass="TerritoryAttachment" type="territory">	<option name="production" value="1"/>			</attachment>
-<attachment name="territoryAttachment" attachTo="Tarakan-E.Borneo" 			javaClass="TerritoryAttachment" type="territory">	<option name="production" value="1"/>			</attachment>
+<attachment name="territoryAttachment" attachTo="Tarakan-E.Borneo" 			javaClass="TerritoryAttachment" type="territory">	<option name="production" value="3"/>			</attachment>
 <attachment name="territoryAttachment" attachTo="Tarawa-Gilbert Is." 		javaClass="TerritoryAttachment" type="territory">	<option name="production" value="1"/>			</attachment>
 <attachment name="territoryAttachment" attachTo="Tasmania" 					javaClass="TerritoryAttachment" type="territory">	<option name="production" value="1"/>														</attachment>
 <attachment name="territoryAttachment" attachTo="Taymyr" 					javaClass="TerritoryAttachment" type="territory">	<option name="production" value="1"/>			</attachment>
-<attachment name="territoryAttachment" attachTo="Tbilisi-Georgia" 			javaClass="TerritoryAttachment" type="territory">	<option name="production" value="1"/>		</attachment>
+<attachment name="territoryAttachment" attachTo="Tbilisi-Georgia" 			javaClass="TerritoryAttachment" type="territory">	<option name="production" value="2"/>		</attachment>
 <attachment name="territoryAttachment" attachTo="Tehran" 					javaClass="TerritoryAttachment" type="territory">	<option name="production" value="1"/>			</attachment>
 <attachment name="territoryAttachment" attachTo="Tenere" 					javaClass="TerritoryAttachment" type="territory">	<option name="production" value="0"/>		<option name="isImpassable" value="true"/>	</attachment>
-<attachment name="territoryAttachment" attachTo="Texas" 					javaClass="TerritoryAttachment" type="territory">	<option name="production" value="1"/>														</attachment>
+<attachment name="territoryAttachment" attachTo="Texas" 					javaClass="TerritoryAttachment" type="territory">	<option name="production" value="4"/>														</attachment>
 <attachment name="territoryAttachment" attachTo="Thessaloniki" 				javaClass="TerritoryAttachment" type="territory">	<option name="production" value="1"/>		</attachment>
 <attachment name="territoryAttachment" attachTo="Thrace" 					javaClass="TerritoryAttachment" type="territory">	<option name="production" value="1"/>		</attachment>
 <attachment name="territoryAttachment" attachTo="Tibesti" 					javaClass="TerritoryAttachment" type="territory">	<option name="production" value="0"/>			<option name="isImpassable" value="true"/>	</attachment>
 <attachment name="territoryAttachment" attachTo="W.Algerian-Sahara" 		javaClass="TerritoryAttachment" type="territory">	<option name="production" value="1"/>			</attachment>
 <attachment name="territoryAttachment" attachTo="Timor" 					javaClass="TerritoryAttachment" type="territory">	<option name="production" value="1"/>			</attachment>
 <attachment name="territoryAttachment" attachTo="Tobruk" 					javaClass="TerritoryAttachment" type="territory">	<option name="production" value="1"/>														</attachment>
-<attachment name="territoryAttachment" attachTo="Tohoku" 					javaClass="TerritoryAttachment" type="territory">	<option name="production" value="1"/>		</attachment>
+<attachment name="territoryAttachment" attachTo="Tohoku" 					javaClass="TerritoryAttachment" type="territory">	<option name="production" value="2"/>		</attachment>
 <attachment name="territoryAttachment" attachTo="Tokyo" 					javaClass="TerritoryAttachment" type="territory">
   <option name="capital" value="Japanese"/>
   <option name="production" value="6"/>
@@ -4985,7 +5015,7 @@
 </attachment>
 <attachment name="territoryAttachment" attachTo="Tomsk" 					javaClass="TerritoryAttachment" type="territory">	<option name="production" value="1"/>														</attachment>
 <attachment name="territoryAttachment" attachTo="Toronto-S.Ontario" 		javaClass="TerritoryAttachment" type="territory">	<option name="production" value="1"/>			</attachment>
-<attachment name="territoryAttachment" attachTo="Toulouse-Occitania" 		javaClass="TerritoryAttachment" type="territory">	<option name="production" value="1"/>														</attachment>
+<attachment name="territoryAttachment" attachTo="Toulouse-Occitania" 		javaClass="TerritoryAttachment" type="territory">	<option name="production" value="2"/>														</attachment>
 <attachment name="territoryAttachment" attachTo="Transdanubia" 				javaClass="TerritoryAttachment" type="territory">	<option name="production" value="1"/>														</attachment>
 <attachment name="territoryAttachment" attachTo="Transylvania" 				javaClass="TerritoryAttachment" type="territory">	<option name="production" value="1"/>		</attachment>
 <attachment name="territoryAttachment" attachTo="Trebizond" 				javaClass="TerritoryAttachment" type="territory">	<option name="production" value="1"/>														</attachment>
@@ -4993,14 +5023,14 @@
 <attachment name="territoryAttachment" attachTo="Troms-Finnmark" 			javaClass="TerritoryAttachment" type="territory">	<option name="production" value="1"/>		</attachment>
 <attachment name="territoryAttachment" attachTo="Trondheim" 				javaClass="TerritoryAttachment" type="territory">	<option name="production" value="1"/>		</attachment>
 <attachment name="territoryAttachment" attachTo="Trucial Coast" 			javaClass="TerritoryAttachment" type="territory">	<option name="production" value="1"/>														</attachment>
-<attachment name="territoryAttachment" attachTo="Truk-Coraline Is." 		javaClass="TerritoryAttachment" type="territory">	<option name="production" value="1"/>															</attachment>
+<attachment name="territoryAttachment" attachTo="Truk-Coraline Is." 		javaClass="TerritoryAttachment" type="territory">	<option name="production" value="3"/>															</attachment>
 <attachment name="territoryAttachment" attachTo="Tsagaan Olom" 				javaClass="TerritoryAttachment" type="territory">	<option name="production" value="1"/>														</attachment>
 <attachment name="territoryAttachment" attachTo="Tsinghai" 					javaClass="TerritoryAttachment" type="territory">	<option name="production" value="1"/>														</attachment>
 <attachment name="territoryAttachment" attachTo="Tula" 						javaClass="TerritoryAttachment" type="territory">	<option name="production" value="1"/>														</attachment>
-<attachment name="territoryAttachment" attachTo="Tunis-Tunisia" 			javaClass="TerritoryAttachment" type="territory">	<option name="production" value="1"/>														</attachment>
+<attachment name="territoryAttachment" attachTo="Tunis-Tunisia" 			javaClass="TerritoryAttachment" type="territory">	<option name="production" value="2"/>														</attachment>
 <attachment name="territoryAttachment" attachTo="Turkmenistan" 				javaClass="TerritoryAttachment" type="territory">	<option name="production" value="1"/>													</attachment>
 <attachment name="territoryAttachment" attachTo="Tver" 						javaClass="TerritoryAttachment" type="territory">	<option name="production" value="1"/>														</attachment>
-<attachment name="territoryAttachment" attachTo="Tyrol-S.Austria" 			javaClass="TerritoryAttachment" type="territory">	<option name="production" value="1"/>														</attachment>
+<attachment name="territoryAttachment" attachTo="Tyrol-S.Austria" 			javaClass="TerritoryAttachment" type="territory">	<option name="production" value="2"/>														</attachment>
 <attachment name="territoryAttachment" attachTo="Tyumen" 					javaClass="TerritoryAttachment" type="territory">	<option name="production" value="1"/>														</attachment>
 <attachment name="territoryAttachment" attachTo="Ubangi Sheri" 				javaClass="TerritoryAttachment" type="territory">	<option name="production" value="1"/>			</attachment>
 <attachment name="territoryAttachment" attachTo="Udon Thani" 				javaClass="TerritoryAttachment" type="territory">	<option name="production" value="1"/>			</attachment>
@@ -5011,39 +5041,42 @@
 <attachment name="territoryAttachment" attachTo="Upper Volta" 				javaClass="TerritoryAttachment" type="territory">	<option name="production" value="1"/>			</attachment>
 <attachment name="territoryAttachment" attachTo="Uruguay" 					javaClass="TerritoryAttachment" type="territory">	<option name="production" value="1"/>														</attachment>
 <attachment name="territoryAttachment" attachTo="Urumchi-Kansu" 			javaClass="TerritoryAttachment" type="territory">	<option name="production" value="1"/>														</attachment>
-<attachment name="territoryAttachment" attachTo="Utah" 						javaClass="TerritoryAttachment" type="territory">	<option name="production" value="1"/>														</attachment>
+<attachment name="territoryAttachment" attachTo="Utah" 						javaClass="TerritoryAttachment" type="territory">	<option name="production" value="3"/>														</attachment>
 <attachment name="territoryAttachment" attachTo="Uzbekistan" 				javaClass="TerritoryAttachment" type="territory">	<option name="production" value="1"/>															</attachment>
 <attachment name="territoryAttachment" attachTo="Valencia" 					javaClass="TerritoryAttachment" type="territory">	<option name="production" value="1"/>														</attachment>
 <attachment name="territoryAttachment" attachTo="Vancouver-W.British Columbia" javaClass="TerritoryAttachment" type="territory">	<option name="production" value="1"/>		</attachment>">
 <attachment name="territoryAttachment" attachTo="Varna" 					javaClass="TerritoryAttachment" type="territory">	<option name="production" value="1"/>			</attachment>
-<attachment name="territoryAttachment" attachTo="Venice-Trieste" 			javaClass="TerritoryAttachment" type="territory">	<option name="production" value="1"/>			</attachment>
+<attachment name="territoryAttachment" attachTo="Venice-Trieste" 			javaClass="TerritoryAttachment" type="territory">	<option name="production" value="2"/>			</attachment>
 <attachment name="territoryAttachment" attachTo="Veracruz" 					javaClass="TerritoryAttachment" type="territory">	<option name="production" value="1"/>			</attachment>
-<attachment name="territoryAttachment" attachTo="Vichy-Rhone" 				javaClass="TerritoryAttachment" type="territory">	<option name="production" value="1"/>		</attachment>
+<attachment name="territoryAttachment" attachTo="Vichy-Rhone" 				javaClass="TerritoryAttachment" type="territory">	<option name="production" value="2"/>		</attachment>
 <attachment name="territoryAttachment" attachTo="Victoria" 					javaClass="TerritoryAttachment" type="territory">	<option name="production" value="1"/>			</attachment>
-<attachment name="territoryAttachment" attachTo="Vienna-N.Austria" 			javaClass="TerritoryAttachment" type="territory">	<option name="production" value="1"/>			</attachment>
+<attachment name="territoryAttachment" attachTo="Vienna-N.Austria" 			javaClass="TerritoryAttachment" type="territory">	<option name="production" value="3"/>			</attachment>
 <attachment name="territoryAttachment" attachTo="Vilna" 					javaClass="TerritoryAttachment" type="territory">	<option name="production" value="1"/>														</attachment>
-<attachment name="territoryAttachment" attachTo="Virginia" 					javaClass="TerritoryAttachment" type="territory">	<option name="production" value="1"/>														</attachment>
+<attachment name="territoryAttachment" attachTo="Virginia" 					javaClass="TerritoryAttachment" type="territory">	<option name="production" value="4"/>														</attachment>
 <attachment name="territoryAttachment" attachTo="Vitebsk" 					javaClass="TerritoryAttachment" type="territory">	<option name="production" value="1"/>														</attachment>
-<attachment name="territoryAttachment" attachTo="Vladivostok" 				javaClass="TerritoryAttachment" type="territory">	<option name="production" value="1"/>														</attachment>
+<attachment name="territoryAttachment" attachTo="Vladivostok" 				javaClass="TerritoryAttachment" type="territory">	<option name="production" value="2"/>														</attachment>
 <attachment name="territoryAttachment" attachTo="Vologda" 					javaClass="TerritoryAttachment" type="territory">	<option name="production" value="1"/>														</attachment>
 <attachment name="territoryAttachment" attachTo="Vyborg" 					javaClass="TerritoryAttachment" type="territory">	<option name="production" value="1"/>			</attachment>
 <attachment name="territoryAttachment" attachTo="W.Tibet" 					javaClass="TerritoryAttachment" type="territory">	<option name="production" value="0"/>		<option name="isImpassable" value="true"/>	</attachment>
-<attachment name="territoryAttachment" attachTo="Wake Is." 					javaClass="TerritoryAttachment" type="territory">	<option name="production" value="1"/>			</attachment>
+<attachment name="territoryAttachment" attachTo="Wake Is." 					javaClass="TerritoryAttachment" type="territory">	<option name="production" value="2"/>			</attachment>
 <attachment name="territoryAttachment" attachTo="Wales" 					javaClass="TerritoryAttachment" type="territory">	<option name="production" value="1"/>		</attachment>
-<attachment name="territoryAttachment" attachTo="Wallachia" 				javaClass="TerritoryAttachment" type="territory">	<option name="production" value="1"/>		</attachment>
-<attachment name="territoryAttachment" attachTo="Warsaw-Cen.Poland" 		javaClass="TerritoryAttachment" type="territory">	<option name="production" value="1"/>			</attachment>
+<attachment name="territoryAttachment" attachTo="Wallachia" 				javaClass="TerritoryAttachment" type="territory">	<option name="production" value="2"/>		</attachment>
+<attachment name="territoryAttachment" attachTo="Warsaw-Cen.Poland" 		javaClass="TerritoryAttachment" type="territory">	<option name="production" value="3"/>			</attachment>
 <attachment name="territoryAttachment" attachTo="Washington D.C." 			javaClass="TerritoryAttachment" type="territory">
   <option name="production" value="6"/>			
   <option name="capital" value="Americans"/>
   <option name="victoryCity" value="1"/>
 </attachment>
-<attachment name="territoryAttachment" attachTo="Westphalia-Rhineland" 		javaClass="TerritoryAttachment" type="territory">	<option name="production" value="1"/>			</attachment>
+<attachment name="territoryAttachment" attachTo="Westphalia-Rhineland" 		javaClass="TerritoryAttachment" type="territory">	<option name="production" value="5"/>			</attachment>
 <attachment name="territoryAttachment" attachTo="Windhoek" 					javaClass="TerritoryAttachment" type="territory">	<option name="production" value="1"/>														</attachment>
 <attachment name="territoryAttachment" attachTo="Windward Is." 				javaClass="TerritoryAttachment" type="territory">	<option name="production" value="1"/>			</attachment>
 <attachment name="territoryAttachment" attachTo="Winnipeg" 					javaClass="TerritoryAttachment" type="territory">	<option name="production" value="1"/>			</attachment>
-<attachment name="territoryAttachment" attachTo="Wisconsin-Minnesota" 		javaClass="TerritoryAttachment" type="territory">	<option name="production" value="1"/>			</attachment>
-<attachment name="territoryAttachment" attachTo="Wuhan" 					javaClass="TerritoryAttachment" type="territory">	<option name="production" value="1"/>														</attachment>
-<attachment name="territoryAttachment" attachTo="Wyoming" 					javaClass="TerritoryAttachment" type="territory">	<option name="production" value="1"/>														</attachment>
+<attachment name="territoryAttachment" attachTo="Wisconsin-Minnesota" 		javaClass="TerritoryAttachment" type="territory">	<option name="production" value="3"/>			</attachment>
+<attachment name="territoryAttachment" attachTo="Wuhan" javaClass="TerritoryAttachment" type="territory">	
+	<option name="production" value="2"/>
+	<option name="originalOwner" value="Chinese"/>														
+</attachment>
+<attachment name="territoryAttachment" attachTo="Wyoming" 					javaClass="TerritoryAttachment" type="territory">	<option name="production" value="3"/>														</attachment>
 <attachment name="territoryAttachment" attachTo="Yakutia" 					javaClass="TerritoryAttachment" type="territory">	<option name="production" value="1"/>			</attachment>
 <attachment name="territoryAttachment" attachTo="Yakutsk" 					javaClass="TerritoryAttachment" type="territory">	<option name="production" value="1"/>														</attachment>
 <attachment name="territoryAttachment" attachTo="Yamalia" 					javaClass="TerritoryAttachment" type="territory">	<option name="production" value="1"/>			</attachment>
@@ -5221,6 +5254,12 @@
       <option name="immuneToBlockade" value="true"/>
     </attachment>
     <!--  Rules Restrictions -->
+    <attachment name="rulesAttachment" attachTo="Chinese" javaClass="games.strategy.triplea.attachments.RulesAttachment" type="player">
+      <option name="placementAnyTerritory" value="true"/>
+      <option name="placementCapturedTerritory" value="true"/>
+      <option name="placementPerTerritory" value="9999999"/>
+      <option name="unlimitedProduction" value="true"/>
+    </attachment>
     <!-- Political Action Attachments -->
     <!-- Tech Ability Attachment -->
     <attachment name="techAbilityAttachment" attachTo="superSub" javaClass="games.strategy.triplea.attachments.TechAbilityAttachment" type="technology">
@@ -5563,7 +5602,7 @@
 	<territoryOwner territory="Brittany" 	 	 	 	 	owner="Germans"/>		<!-- -->
 	<territoryOwner territory="Broome-Exmouth" 	 	 	 	owner="ANZAC"/><!-- -->
 	<territoryOwner territory="Bryansk" 	 	 	 	 	owner="Russians"/>			<!-- -->
-	<territoryOwner territory="Bucharest-Cen.Romania" 	 	owner="Italians"/>			<!-- -->
+	<territoryOwner territory="Bucharest-Cen.Romania" 	 	owner="Germans"/>			<!-- -->
 	<territoryOwner territory="Budapest-N.Hungary" 	 	 	owner="Germans"/>		<!-- -->
 	<territoryOwner territory="Buenos Aires" 	 	 	 	owner="Neutral_True"/>		<!-- S.America -->
 	<territoryOwner territory="Buru" 	 	 	 	 	 	owner="ANZAC"/><!-- -->
@@ -5732,7 +5771,7 @@
 	<territoryOwner territory="Khartoum-Sudan" 	 	 	 	owner="British"/>		<!-- -->
 	<territoryOwner territory="Kherson" 	 	 	 	 	owner="Russians"/>			<!-- -->
 	<territoryOwner territory="Khorasan" 	 	 	 	 	owner="Russians"/>			<!-- Iran -->
-	<territoryOwner territory="Kiangsi" 	 	 	 	 	owner="Japanese"/>			<!-- -->
+	<territoryOwner territory="Kiangsi" 	 	 	 	 	owner="Chinese"/>			<!-- -->
 	<territoryOwner territory="Kilwa" 	 	 	 	 	 	owner="British"/>		<!-- -->
 	<territoryOwner territory="King Salmon-Aleut Pen." 	 	owner="Americans"/>			<!-- -->
 	<territoryOwner territory="Kirov" 	 	 	 	 	 	owner="Russians"/>			<!-- -->
@@ -5756,7 +5795,7 @@
 	<territoryOwner territory="Kuwait" 	 	 	 	 	 	owner="British"/>		<!-- -->
 	<territoryOwner territory="Kuybysev" 	 	 	 	 	owner="Russians"/>			<!-- -->
 	<territoryOwner territory="Kwajalein-Marshall Is." 	 	owner="Japanese"/>			<!-- -->
-	<territoryOwner territory="Kwangsi" 	 	 	 	 	owner="Japanese"/>			<!-- -->
+	<territoryOwner territory="Kwangsi" 	 	 	 	 	owner="Chinese"/>			<!-- -->
 	<territoryOwner territory="Kweichow" 	 	 	 	 	owner="Chinese"/>			<!-- -->
 	<territoryOwner territory="Kyiv-Cen.Ukraine" 	 	 	owner="Russians"/>			<!-- -->
 	<territoryOwner territory="Kyoto-Osaka" 	 	 	 	owner="Japanese"/>			<!-- -->
@@ -5891,7 +5930,7 @@
 	<territoryOwner territory="Panama" 	 	 	 	 	 	owner="Americans"/>			<!-- -->
 	<territoryOwner territory="Panay Leyte-Visayas Is." 	owner="Americans"/>			<!-- -->
 	<territoryOwner territory="Paraguay" 	 	 	 	 	owner="Neutral_True"/>		<!-- S.America -->
-	<territoryOwner territory="Paris" 	 	 	owner="Germans"/>		<!-- -->
+	<territoryOwner territory="Paris" 	 	 	owner="Germans"/>		<!-- France -->
 	<territoryOwner territory="Patagonia" 	 	 	 	 	owner="Neutral_True"/>		<!-- S.America -->
 	<territoryOwner territory="Peking-Tientsin" 	 	 	owner="Japanese"/>			<!-- -->
 	<territoryOwner territory="Pelelui-Palau Is." 	 	 	owner="Japanese"/>			<!-- -->
@@ -5900,7 +5939,7 @@
 	<territoryOwner territory="Perth-W.Australia" 	 	 	owner="ANZAC"/><!-- -->
 	<territoryOwner territory="Peru" 	 	 	 	 	 	owner="Neutral_True"/>		<!-- S.America -->
 	<territoryOwner territory="Phoenix Is." 	 	 	 	owner="ANZAC"/><!-- -->
-	<territoryOwner territory="Ploiesti-E.Romania" 	 	 	owner="Italians"/>			<!-- -->
+	<territoryOwner territory="Ploiesti-E.Romania" 	 	 	owner="Germans"/>			<!-- -->
 	<territoryOwner territory="Poitou" 	 	 	 	 	 	owner="Germans"/>		<!-- -->
 	<territoryOwner territory="Pomerania" 	 	 	 	 	owner="Germans"/>		<!-- -->
 	<territoryOwner territory="Port Au Prince-Haiti" 	 	owner="Neutral_True"/>		<!-- -->
@@ -6058,7 +6097,7 @@
 <!--	<territoryOwner territory="W.Tibet" 	 	 	 	 	owner="Neutral_True"/> -->		<!-- -->
 	<territoryOwner territory="Wake Is." 	 	 	 	 	owner="Americans"/>			<!-- -->
 	<territoryOwner territory="Wales" 	 	 	 	 	 	owner="British"/>		<!-- -->
-	<territoryOwner territory="Wallachia" 	 	 	 	 	owner="Italians"/>			<!-- -->
+	<territoryOwner territory="Wallachia" 	 	 	 	 	owner="Germans"/>			<!-- -->
 	<territoryOwner territory="Warsaw-Cen.Poland" 	 	 	owner="Germans"/>		<!-- -->
 	<territoryOwner territory="Washington D.C." 	 	 	owner="Americans"/>			<!-- -->
 	<territoryOwner territory="Westphalia-Rhineland" 	 	owner="Germans"/>		<!-- -->
@@ -6066,7 +6105,7 @@
 	<territoryOwner territory="Windward Is." 	 	 	 	owner="British"/>		<!-- -->
 	<territoryOwner territory="Winnipeg" 	 	 	 	 	owner="British"/>		<!-- -->
 	<territoryOwner territory="Wisconsin-Minnesota" 	 	owner="Americans"/>			<!-- -->
-	<territoryOwner territory="Wuhan" 	 	 	 	 	 	owner="Chinese"/>			<!-- -->
+	<territoryOwner territory="Wuhan" 	 	 	 	 	 	owner="Japanese"/>			<!-- -->
 	<territoryOwner territory="Wyoming" 	 	 	 	 	owner="Americans"/>			<!-- -->
 	<territoryOwner territory="Yakutia" 	 	 	 	 	owner="Russians"/>			<!-- -->
 	<territoryOwner territory="Yakutsk" 	 	 	 	 	owner="Russians"/>			<!-- -->
@@ -6080,39 +6119,8 @@
 
       </ownerInitialize>
       <unitInitialize>
-	<!-- Germans -->
-	<unitPlacement unitType="infantry" territory="Belgium" quantity="2" owner="Germans"/>
-            <unitPlacement unitType="factory_major" territory="Berlin" quantity="1" owner="Germans"/>
-            <unitPlacement unitType="airfield" territory="Berlin" quantity="1" owner="Germans"/>
-            <unitPlacement unitType="aaGun" territory="Berlin" quantity="1" owner="Germans"/>
-            <unitPlacement unitType="infantry" territory="Berlin" quantity="1" owner="Germans"/>
-            <unitPlacement unitType="artillery" territory="Berlin" quantity="1" owner="Germans"/>
-            <unitPlacement unitType="mech_infantry" territory="Berlin" quantity="1" owner="Germans"/>
-            <unitPlacement unitType="armour" territory="Berlin" quantity="1" owner="Germans"/>
-            <unitPlacement unitType="fighter" territory="Berlin" quantity="1" owner="Germans"/>
-            <unitPlacement unitType="tactical_bomber" territory="Berlin" quantity="1" owner="Germans"/>
-            <unitPlacement unitType="bomber" territory="Berlin" quantity="1" owner="Germans"/>
-            <unitPlacement unitType="infantry" territory="Bordeaux-Gascony" quantity="2" owner="Germans"/>
-            <unitPlacement unitType="infantry" territory="Brittany" quantity="2" owner="Germans"/>
-	    <unitPlacement unitType="fighter" territory="Brittany" quantity="1" owner="Germans"/>
-            <unitPlacement unitType="aaGun" territory="Brittany" quantity="1" owner="Germans"/>
-            <unitPlacement unitType="harbour" territory="Brittany" quantity="1" owner="Germans"/>
-            <unitPlacement unitType="infantry" territory="Calais" quantity="2" owner="Germans"/>
-            <unitPlacement unitType="infantry" territory="Konigsberg-E.Prussia" quantity="3" owner="Germans"/>
-            <unitPlacement unitType="artillery" territory="Konigsberg-E.Prussia" quantity="1" owner="Germans"/>
-            <unitPlacement unitType="mech_infantry" territory="Konigsberg-E.Prussia" quantity="1" owner="Germans"/>
-            <unitPlacement unitType="armour" territory="Konigsberg-E.Prussia" quantity="1" owner="Germans"/>
-            <unitPlacement unitType="infantry" territory="Kosice-Munkacs" quantity="3" owner="Germans"/>
-            <unitPlacement unitType="infantry" territory="Krakow-Lublin" quantity="3" owner="Germans"/>
-	    <unitPlacement unitType="infantry" territory="Normandy" quantity="2" owner="Germans"/>
-            <unitPlacement unitType="factory_minor" territory="Paris" quantity="1" owner="Germans"/>
-            <unitPlacement unitType="infantry" territory="Ploiesti-E.Romania" quantity="3" owner="Germans"/>
-            <unitPlacement unitType="infantry" territory="Poitou" quantity="2" owner="Germans"/>
-	    <unitPlacement unitType="factory_major" territory="Schleswig-Holstein" quantity="1" owner="Germans"/>
-            <unitPlacement unitType="harbour" territory="Schleswig-Holstein" quantity="1" owner="Germans"/>
-	    <unitPlacement unitType="infantry" territory="Warsaw-Cen.Poland" quantity="3" owner="Germans"/>
-
-	    <unitPlacement unitType="submarine" territory="087 B Sea Zone" quantity="1" owner="Germans"/>
+	    <!-- Germans -->
+            <unitPlacement unitType="submarine" territory="087 B Sea Zone" quantity="1" owner="Germans"/>
             <unitPlacement unitType="submarine" territory="088 A Sea Zone" quantity="1" owner="Germans"/>
             <unitPlacement unitType="submarine" territory="090 Sea Zone" quantity="1" owner="Germans"/>
             <unitPlacement unitType="transport" territory="093 Sea Zone" quantity="2" owner="Germans"/>
@@ -6135,30 +6143,50 @@
             <unitPlacement unitType="cruiser" territory="114 Sea Zone" quantity="1" owner="Germans"/>
             <unitPlacement unitType="submarine" territory="117 Sea Zone" quantity="1" owner="Germans"/>
             <unitPlacement unitType="submarine" territory="123 Sea Zone" quantity="2" owner="Germans"/>
-	    <unitPlacement unitType="infantry" territory="Algiers" quantity="1" owner="Germans"/>
+            <unitPlacement unitType="infantry" territory="Algiers" quantity="1" owner="Germans"/>
             <unitPlacement unitType="infantry" territory="Athens-Cen.Greece" quantity="2" owner="Germans"/>
             <unitPlacement unitType="aaGun" territory="Athens-Cen.Greece" quantity="1" owner="Germans"/>
             <unitPlacement unitType="infantry" territory="Baden-Wurttemburg" quantity="1" owner="Germans"/>
             <unitPlacement unitType="infantry" territory="Bavaria" quantity="2" owner="Germans"/>
             <unitPlacement unitType="factory_minor" territory="Bavaria" quantity="1" owner="Germans"/>
             <unitPlacement unitType="aaGun" territory="Bavaria" quantity="1" owner="Germans"/>
+            <unitPlacement unitType="infantry" territory="Belgium" quantity="2" owner="Germans"/>
+            <unitPlacement unitType="harbour" territory="Belgium" quantity="1" owner="Germans"/>
             <unitPlacement unitType="infantry" territory="Belgrade-Cen.Yugoslavia" quantity="1" owner="Germans"/>
             <unitPlacement unitType="infantry" territory="Bergen-Vestland" quantity="2" owner="Germans"/>
-	    <unitPlacement unitType="infantry" territory="Bona" quantity="2" owner="Germans"/>
-	    <unitPlacement unitType="tactical_bomber" territory="Bucharest-Cen.Romania" quantity="1" owner="Germans"/>
+            <unitPlacement unitType="factory_major" territory="Berlin" quantity="1" owner="Germans"/>
+            <unitPlacement unitType="airfield" territory="Berlin" quantity="1" owner="Germans"/>
+            <unitPlacement unitType="aaGun" territory="Berlin" quantity="3" owner="Germans"/>
+            <unitPlacement unitType="infantry" territory="Berlin" quantity="5" owner="Germans"/>
+            <unitPlacement unitType="artillery" territory="Berlin" quantity="1" owner="Germans"/>
+            <unitPlacement unitType="mech_infantry" territory="Berlin" quantity="2" owner="Germans"/>
+            <unitPlacement unitType="armour" territory="Berlin" quantity="3" owner="Germans"/>
+            <unitPlacement unitType="fighter" territory="Berlin" quantity="1" owner="Germans"/>
+            <unitPlacement unitType="tactical_bomber" territory="Berlin" quantity="1" owner="Germans"/>
+            <unitPlacement unitType="bomber" territory="Berlin" quantity="1" owner="Germans"/>
+            <unitPlacement unitType="infantry" territory="Bona" quantity="2" owner="Germans"/>
+            <unitPlacement unitType="infantry" territory="Bordeaux-Gascony" quantity="2" owner="Germans"/>
+            <unitPlacement unitType="infantry" territory="Brittany" quantity="2" owner="Germans"/>
+            <unitPlacement unitType="fighter" territory="Brittany" quantity="1" owner="Germans"/>
+            <unitPlacement unitType="aaGun" territory="Brittany" quantity="1" owner="Germans"/>
+            <unitPlacement unitType="harbour" territory="Brittany" quantity="1" owner="Germans"/>
+            <unitPlacement unitType="infantry" territory="Bucharest-Cen.Romania" quantity="5" owner="Germans"/>
+            <unitPlacement unitType="fighter" territory="Bucharest-Cen.Romania" quantity="1" owner="Germans"/>
+            <unitPlacement unitType="tactical_bomber" territory="Bucharest-Cen.Romania" quantity="1" owner="Germans"/>
             <unitPlacement unitType="factory_minor" territory="Bucharest-Cen.Romania" quantity="1" owner="Germans"/>
             <unitPlacement unitType="aaGun" territory="Bucharest-Cen.Romania" quantity="1" owner="Germans"/>
             <unitPlacement unitType="artillery" territory="Bucharest-Cen.Romania" quantity="1" owner="Germans"/>
             <unitPlacement unitType="infantry" territory="Budapest-N.Hungary" quantity="4" owner="Germans"/>
             <unitPlacement unitType="armour" territory="Budapest-N.Hungary" quantity="1" owner="Germans"/>
-	    <unitPlacement unitType="infantry" territory="Copenhagen-Denmark" quantity="1" owner="Germans"/>
+            <unitPlacement unitType="infantry" territory="Calais" quantity="2" owner="Germans"/>
+            <unitPlacement unitType="infantry" territory="Copenhagen-Denmark" quantity="1" owner="Germans"/>
             <unitPlacement unitType="infantry" territory="Danzig-Posen" quantity="4" owner="Germans"/>
             <unitPlacement unitType="artillery" territory="Danzig-Posen" quantity="2" owner="Germans"/>
             <unitPlacement unitType="armour" territory="Danzig-Posen" quantity="1" owner="Germans"/>
             <unitPlacement unitType="mech_infantry" territory="Danzig-Posen" quantity="1" owner="Germans"/>
             <unitPlacement unitType="infantry" territory="Frankfurt-Hesse" quantity="1" owner="Germans"/>
-	    <unitPlacement unitType="factory_minor" territory="Frankfurt-Hesse" quantity="1" owner="Germans"/>
-	    <unitPlacement unitType="infantry" territory="Hamburg" quantity="3" owner="Germans"/>
+            <unitPlacement unitType="factory_minor" territory="Frankfurt-Hesse" quantity="1" owner="Germans"/>
+            <unitPlacement unitType="infantry" territory="Hamburg" quantity="3" owner="Germans"/>
             <unitPlacement unitType="fighter" territory="Hamburg" quantity="1" owner="Germans"/>
             <unitPlacement unitType="tactical_bomber" territory="Hamburg" quantity="1" owner="Germans"/>
             <unitPlacement unitType="aaGun" territory="Hamburg" quantity="1" owner="Germans"/>
@@ -6214,6 +6242,7 @@
             <unitPlacement unitType="infantry" territory="Pomerania" quantity="3" owner="Germans"/>
             <unitPlacement unitType="infantry" territory="Prague-Bohemia Moravia" quantity="3" owner="Germans"/>
             <unitPlacement unitType="infantry" territory="Provence-Marseille" quantity="2" owner="Germans"/>
+            <unitPlacement unitType="harbour" territory="Provence-Marseille" quantity="1" owner="Germans"/>
             <unitPlacement unitType="infantry" territory="Savo-Ostrobothnia" quantity="2" owner="Germans"/>
             <unitPlacement unitType="artillery" territory="Savo-Ostrobothnia" quantity="1" owner="Germans"/>
             <unitPlacement unitType="factory_major" territory="Schleswig-Holstein" quantity="1" owner="Germans"/>
@@ -6256,18 +6285,10 @@
             <unitPlacement unitType="factory_major" territory="Westphalia-Rhineland" quantity="1" owner="Germans"/>
 
 
-	<!-- Russians -->
-	<unitPlacement unitType="factory_major" territory="Moscow-Cen.Russia" quantity="1" owner="Russians"/>
-            <unitPlacement unitType="fighter" territory="Moscow-Cen.Russia" quantity="1" owner="Russians"/>
-            <unitPlacement unitType="airfield" territory="Moscow-Cen.Russia" quantity="1" owner="Russians"/>
-            <unitPlacement unitType="infantry" territory="Moscow-Cen.Russia" quantity="1" owner="Russians"/>
-            <unitPlacement unitType="tactical_bomber" territory="Moscow-Cen.Russia" quantity="1" owner="Russians"/>
-            <unitPlacement unitType="armour" territory="Moscow-Cen.Russia" quantity="1" owner="Russians"/>
-            <unitPlacement unitType="bomber" territory="Moscow-Cen.Russia" quantity="1" owner="Russians"/>
-            <unitPlacement unitType="aaGun" territory="Moscow-Cen.Russia" quantity="1" owner="Russians"/>
-            <unitPlacement unitType="mech_infantry" territory="Moscow-Cen.Russia" quantity="1" owner="Russians"/>
-            <unitPlacement unitType="artillery" territory="Moscow-Cen.Russia" quantity="1" owner="Russians"/>
-<unitPlacement unitType="destroyer" territory="100 C Sea Zone" quantity="2" owner="Russians"/>
+
+
+	    <!-- Russians -->
+            <unitPlacement unitType="destroyer" territory="100 C Sea Zone" quantity="2" owner="Russians"/>
             <unitPlacement unitType="transport" territory="100 C Sea Zone" quantity="1" owner="Russians"/>
             <unitPlacement unitType="destroyer" territory="115 Sea Zone" quantity="1" owner="Russians"/>
             <unitPlacement unitType="cruiser" territory="115 Sea Zone" quantity="1" owner="Russians"/>
@@ -6301,9 +6322,7 @@
             <unitPlacement unitType="infantry" territory="Gizhiga" quantity="1" owner="Russians"/>
             <unitPlacement unitType="infantry" territory="Grodno" quantity="2" owner="Russians"/>
             <unitPlacement unitType="mech_infantry" territory="Grodno" quantity="1" owner="Russians"/>
-            <unitPlacement unitType="infantry" territory="Irkutsk" quantity="2" owner="Russians"/>
-            <unitPlacement unitType="artillery" territory="Irkutsk" quantity="1" owner="Russians"/>
-            <unitPlacement unitType="mech_infantry" territory="Irkutsk" quantity="1" owner="Russians"/>
+            <unitPlacement unitType="infantry" territory="Irkutsk" quantity="1" owner="Russians"/>
             <unitPlacement unitType="infantry" territory="Kamchatka" quantity="1" owner="Russians"/>
             <unitPlacement unitType="infantry" territory="Karelia" quantity="2" owner="Russians"/>
             <unitPlacement unitType="infantry" territory="Kazan" quantity="1" owner="Russians"/>
@@ -6347,6 +6366,16 @@
             <unitPlacement unitType="infantry" territory="Mariupol" quantity="1" owner="Russians"/>
             <unitPlacement unitType="infantry" territory="Minsk" quantity="2" owner="Russians"/>
             <unitPlacement unitType="infantry" territory="Moldavia" quantity="1" owner="Russians"/>
+            <unitPlacement unitType="factory_major" territory="Moscow-Cen.Russia" quantity="1" owner="Russians"/>
+            <unitPlacement unitType="fighter" territory="Moscow-Cen.Russia" quantity="1" owner="Russians"/>
+            <unitPlacement unitType="airfield" territory="Moscow-Cen.Russia" quantity="1" owner="Russians"/>
+            <unitPlacement unitType="tactical_bomber" territory="Moscow-Cen.Russia" quantity="1" owner="Russians"/>
+            <unitPlacement unitType="bomber" territory="Moscow-Cen.Russia" quantity="1" owner="Russians"/>
+            <unitPlacement unitType="aaGun" territory="Moscow-Cen.Russia" quantity="2" owner="Russians"/>
+            <unitPlacement unitType="mech_infantry" territory="Moscow-Cen.Russia" quantity="1" owner="Russians"/>
+            <unitPlacement unitType="infantry" territory="Moscow-Cen.Russia" quantity="4" owner="Russians"/>
+            <unitPlacement unitType="armour" territory="Moscow-Cen.Russia" quantity="1" owner="Russians"/>
+            <unitPlacement unitType="artillery" territory="Moscow-Cen.Russia" quantity="2" owner="Russians"/>
             <unitPlacement unitType="infantry" territory="Mozhaysk-Kaluga" quantity="1" owner="Russians"/>
             <unitPlacement unitType="infantry" territory="Murmansk" quantity="2" owner="Russians"/>
             <unitPlacement unitType="infantry" territory="Nenetsia" quantity="1" owner="Russians"/>
@@ -6400,31 +6429,217 @@
             <unitPlacement unitType="infantry" territory="Yakutsk" quantity="2" owner="Russians"/>
             <unitPlacement unitType="mech_infantry" territory="Yakutsk" quantity="1" owner="Russians"/>
             <unitPlacement unitType="infantry" territory="Yaroslavl" quantity="1" owner="Russians"/>
+
 	<!-- Japanese -->
-	<unitPlacement unitType="factory_major" territory="Tokyo" quantity="1" owner="Japanese"/>
-	<unitPlacement unitType="factory_minor" territory="Kyushu" quantity="1" owner="Japanese"/>
-	<unitPlacement unitType="harbour" territory="Kyushu" quantity="1" owner="Japanese"/>
-	<unitPlacement unitType="artillery" territory="Tohoku" quantity="1" owner="Japanese"/>
-            <unitPlacement unitType="bomber" territory="Tohoku" quantity="1" owner="Japanese"/>
-            <unitPlacement unitType="mech_infantry" territory="Tohoku" quantity="1" owner="Japanese"/>
-            <unitPlacement unitType="armour" territory="Tohoku" quantity="1" owner="Japanese"/>
-	    <unitPlacement unitType="infantry" territory="Tokyo" quantity="1" owner="Japanese"/>
-            <unitPlacement unitType="tactical_bomber" territory="Tokyo" quantity="1" owner="Japanese"/>
-            <unitPlacement unitType="airfield" territory="Tokyo" quantity="1" owner="Japanese"/>
-            <unitPlacement unitType="artillery" territory="Tokyo" quantity="1" owner="Japanese"/>
+            <unitPlacement unitType="transport" territory="006 A Sea Zone" quantity="1" owner="Japanese"/>
+            <unitPlacement unitType="destroyer" territory="006 A Sea Zone" quantity="1" owner="Japanese"/>
+            <unitPlacement unitType="fighter" territory="006 C Sea Zone" quantity="1" owner="Japanese"/>
+            <unitPlacement unitType="submarine" territory="006 C Sea Zone" quantity="2" owner="Japanese"/>
+            <unitPlacement unitType="battleship" territory="006 C Sea Zone" quantity="2" owner="Japanese"/>
+            <unitPlacement unitType="destroyer" territory="006 C Sea Zone" quantity="4" owner="Japanese"/>
+            <unitPlacement unitType="cruiser" territory="006 C Sea Zone" quantity="1" owner="Japanese"/>
+            <unitPlacement unitType="carrier" territory="006 C Sea Zone" quantity="1" owner="Japanese"/>
+            <unitPlacement unitType="transport" territory="006 C Sea Zone" quantity="2" owner="Japanese"/>
+            <unitPlacement unitType="tactical_bomber" territory="006 C Sea Zone" quantity="1" owner="Japanese"/>
+            <unitPlacement unitType="transport" territory="019 A Sea Zone" quantity="1" owner="Japanese"/>
+            <unitPlacement unitType="cruiser" territory="019 A Sea Zone" quantity="1" owner="Japanese"/>
+            <unitPlacement unitType="destroyer" territory="020 Sea Zone" quantity="1" owner="Japanese"/>
+            <unitPlacement unitType="transport" territory="020 Sea Zone" quantity="2" owner="Japanese"/>
+            <unitPlacement unitType="submarine" territory="025 A Sea Zone" quantity="2" owner="Japanese"/>
+            <unitPlacement unitType="fighter" territory="025 A Sea Zone" quantity="4" owner="Japanese"/>
+            <unitPlacement unitType="carrier" territory="025 A Sea Zone" quantity="3" owner="Japanese"/>
+            <unitPlacement unitType="tactical_bomber" territory="025 A Sea Zone" quantity="2" owner="Japanese"/>
+            <unitPlacement unitType="transport" territory="033 A Sea Zone" quantity="2" owner="Japanese"/>
+            <unitPlacement unitType="submarine" territory="033 A Sea Zone" quantity="1" owner="Japanese"/>
+            <unitPlacement unitType="cruiser" territory="033 A Sea Zone" quantity="1" owner="Japanese"/>
+            <unitPlacement unitType="destroyer" territory="033 A Sea Zone" quantity="1" owner="Japanese"/>
+            <unitPlacement unitType="submarine" territory="036 A Sea Zone" quantity="2" owner="Japanese"/>
+            <unitPlacement unitType="artillery" territory="036 A Sea Zone" quantity="4" owner="Japanese"/>
+            <unitPlacement unitType="infantry" territory="036 A Sea Zone" quantity="8" owner="Japanese"/>
+            <unitPlacement unitType="cruiser" territory="036 A Sea Zone" quantity="1" owner="Japanese"/>
+            <unitPlacement unitType="destroyer" territory="036 A Sea Zone" quantity="6" owner="Japanese"/>
+            <unitPlacement unitType="transport" territory="036 A Sea Zone" quantity="6" owner="Japanese"/>
+            <unitPlacement unitType="fighter" territory="036 A Sea Zone" quantity="2" owner="Japanese"/>
+            <unitPlacement unitType="tactical_bomber" territory="036 A Sea Zone" quantity="2" owner="Japanese"/>
+            <unitPlacement unitType="battleship" territory="036 A Sea Zone" quantity="2" owner="Japanese"/>
+            <unitPlacement unitType="carrier" territory="036 A Sea Zone" quantity="2" owner="Japanese"/>
+            <unitPlacement unitType="infantry" territory="Bangkok-Siam" quantity="1" owner="Japanese"/>
+            <unitPlacement unitType="infantry" territory="Cambodia" quantity="3" owner="Japanese"/>
+            <unitPlacement unitType="artillery" territory="Cambodia" quantity="1" owner="Japanese"/>
+            <unitPlacement unitType="infantry" territory="Chiang Mai" quantity="2" owner="Japanese"/>
+            <unitPlacement unitType="infantry" territory="Chubu" quantity="2" owner="Japanese"/>
+            <unitPlacement unitType="aaGun" territory="Chubu" quantity="1" owner="Japanese"/>
+            <unitPlacement unitType="factory_minor" territory="Chubu" quantity="1" owner="Japanese"/>
+            <unitPlacement unitType="infantry" territory="Da Nang-Annam" quantity="1" owner="Japanese"/>
+            <unitPlacement unitType="infantry" territory="Haichow-Lunghai" quantity="3" owner="Japanese"/>
+            <unitPlacement unitType="infantry" territory="Haikou-Hainan" quantity="1" owner="Japanese"/>
+            <unitPlacement unitType="infantry" territory="Hanoi-Tonkin" quantity="1" owner="Japanese"/>
+            <unitPlacement unitType="infantry" territory="Harbin" quantity="2" owner="Japanese"/>
+            <unitPlacement unitType="infantry" territory="Hiroshima" quantity="1" owner="Japanese"/>
+            <unitPlacement unitType="infantry" territory="Hokkaido" quantity="2" owner="Japanese"/>
+            <unitPlacement unitType="aaGun" territory="Hokkaido" quantity="1" owner="Japanese"/>
+            <unitPlacement unitType="infantry" territory="Hopei" quantity="2" owner="Japanese"/>
+            <unitPlacement unitType="infantry" territory="Iwo Jima-Bonin Is." quantity="2" owner="Japanese"/>
+            <unitPlacement unitType="aaGun" territory="Iwo Jima-Bonin Is." quantity="1" owner="Japanese"/>
+            <unitPlacement unitType="infantry" territory="Jehol-Rehe" quantity="2" owner="Japanese"/>
+            <unitPlacement unitType="infantry" territory="Kra-Buri" quantity="3" owner="Japanese"/>
+            <unitPlacement unitType="infantry" territory="Kwajalein-Marshall Is." quantity="1" owner="Japanese"/>
+            <unitPlacement unitType="infantry" territory="Kyoto-Osaka" quantity="2" owner="Japanese"/>
+            <unitPlacement unitType="aaGun" territory="Kyoto-Osaka" quantity="1" owner="Japanese"/>
+            <unitPlacement unitType="fighter" territory="Kyoto-Osaka" quantity="1" owner="Japanese"/>
+            <unitPlacement unitType="factory_minor" territory="Kyoto-Osaka" quantity="1" owner="Japanese"/>
+            <unitPlacement unitType="aaGun" territory="Kyushu" quantity="2" owner="Japanese"/>
+            <unitPlacement unitType="factory_major" territory="Kyushu" quantity="1" owner="Japanese"/>
+            <unitPlacement unitType="harbour" territory="Kyushu" quantity="1" owner="Japanese"/>
+            <unitPlacement unitType="artillery" territory="Kyushu" quantity="1" owner="Japanese"/>
+            <unitPlacement unitType="infantry" territory="Kyushu" quantity="3" owner="Japanese"/>
+            <unitPlacement unitType="fighter" territory="Kyushu" quantity="1" owner="Japanese"/>
+            <unitPlacement unitType="infantry" territory="Laos" quantity="1" owner="Japanese"/>
+            <unitPlacement unitType="infantry" territory="Manchuria-Manchukuo" quantity="2" owner="Japanese"/>
+            <unitPlacement unitType="infantry" territory="Mukden-Port Arthur" quantity="3" owner="Japanese"/>
+            <unitPlacement unitType="armour" territory="Mukden-Port Arthur" quantity="1" owner="Japanese"/>
+            <unitPlacement unitType="mech_infantry" territory="Mukden-Port Arthur" quantity="1" owner="Japanese"/>
+            <unitPlacement unitType="fighter" territory="Mukden-Port Arthur" quantity="1" owner="Japanese"/>
+            <unitPlacement unitType="tactical_bomber" territory="Mukden-Port Arthur" quantity="1" owner="Japanese"/>
+            <unitPlacement unitType="infantry" territory="N.Korea-Chosen" quantity="1" owner="Japanese"/>
+            <unitPlacement unitType="infantry" territory="Nanking" quantity="2" owner="Japanese"/>
+            <unitPlacement unitType="artillery" territory="Nanking" quantity="1" owner="Japanese"/>
+            <unitPlacement unitType="fighter" territory="Nanking" quantity="1" owner="Japanese"/>
+            <unitPlacement unitType="tactical_bomber" territory="Nanking" quantity="1" owner="Japanese"/>
+            <unitPlacement unitType="infantry" territory="Okinawa-Ryukyu Is." quantity="2" owner="Japanese"/>
+            <unitPlacement unitType="bomber" territory="Okinawa-Ryukyu Is." quantity="1" owner="Japanese"/>
+            <unitPlacement unitType="aaGun" territory="Okinawa-Ryukyu Is." quantity="1" owner="Japanese"/>
+            <unitPlacement unitType="airfield" territory="Okinawa-Ryukyu Is." quantity="1" owner="Japanese"/>
+            <unitPlacement unitType="fighter" territory="Okinawa-Ryukyu Is." quantity="1" owner="Japanese"/>
+            <unitPlacement unitType="infantry" territory="Peking-Tientsin" quantity="1" owner="Japanese"/>
+            <unitPlacement unitType="infantry" territory="Pelelui-Palau Is." quantity="1" owner="Japanese"/>
+            <unitPlacement unitType="infantry" territory="S.Korea-Chosen" quantity="2" owner="Japanese"/>
+            <unitPlacement unitType="infantry" territory="Saigon-Cochinchina" quantity="1" owner="Japanese"/>
+            <unitPlacement unitType="infantry" territory="Saipan-Mariana Is." quantity="1" owner="Japanese"/>
+            <unitPlacement unitType="infantry" territory="Shanghai-Kiangsu" quantity="2" owner="Japanese"/>
+            <unitPlacement unitType="harbour" territory="Shanghai-Kiangsu" quantity="1" owner="Japanese"/>
+            <unitPlacement unitType="infantry" territory="Shangtung" quantity="2" owner="Japanese"/>
+            <unitPlacement unitType="artillery" territory="Shangtung" quantity="1" owner="Japanese"/>
+            <unitPlacement unitType="infantry" territory="Shikoku" quantity="1" owner="Japanese"/>
+            <unitPlacement unitType="infantry" territory="Taipei-Formosa" quantity="3" owner="Japanese"/>
+            <unitPlacement unitType="artillery" territory="Taipei-Formosa" quantity="1" owner="Japanese"/>
+            <unitPlacement unitType="fighter" territory="Taipei-Formosa" quantity="1" owner="Japanese"/>
+            <unitPlacement unitType="infantry" territory="Tohoku" quantity="3" owner="Japanese"/>
+            <unitPlacement unitType="aaGun" territory="Tohoku" quantity="1" owner="Japanese"/>
+            <unitPlacement unitType="armour" territory="Tokyo" quantity="1" owner="Japanese"/>
+            <unitPlacement unitType="factory_major" territory="Tokyo" quantity="1" owner="Japanese"/>
+            <unitPlacement unitType="infantry" territory="Tokyo" quantity="3" owner="Japanese"/>
             <unitPlacement unitType="fighter" territory="Tokyo" quantity="1" owner="Japanese"/>
-            <unitPlacement unitType="aaGun" territory="Tokyo" quantity="1" owner="Japanese"/>
-            <unitPlacement unitType="harbour" territory="Tokyo" quantity="1" owner="Japanese"/>
+            <unitPlacement unitType="bomber" territory="Tokyo" quantity="1" owner="Japanese"/>
+            <unitPlacement unitType="airfield" territory="Tokyo" quantity="1" owner="Japanese"/>
+            <unitPlacement unitType="aaGun" territory="Tokyo" quantity="2" owner="Japanese"/>
+            <unitPlacement unitType="artillery" territory="Tokyo" quantity="1" owner="Japanese"/>
+            <unitPlacement unitType="tactical_bomber" territory="Tokyo" quantity="1" owner="Japanese"/>
+            <unitPlacement unitType="harbour" territory="Truk-Coraline Is." quantity="1" owner="Japanese"/>
+            <unitPlacement unitType="infantry" territory="Truk-Coraline Is." quantity="3" owner="Japanese"/>
+            <unitPlacement unitType="airfield" territory="Truk-Coraline Is." quantity="1" owner="Japanese"/>
+            <unitPlacement unitType="aaGun" territory="Truk-Coraline Is." quantity="1" owner="Japanese"/>
+            <unitPlacement unitType="fighter" territory="Truk-Coraline Is." quantity="2" owner="Japanese"/>
+            <unitPlacement unitType="artillery" territory="Truk-Coraline Is." quantity="1" owner="Japanese"/>
+            <unitPlacement unitType="infantry" territory="Udon Thani" quantity="2" owner="Japanese"/>
+            <unitPlacement unitType="artillery" territory="Udon Thani" quantity="1" owner="Japanese"/>
+            <unitPlacement unitType="infantry" territory="Wuhan" quantity="3" owner="Japanese"/>
 
 	<!-- Americans -->
-	<unitPlacement unitType="factory_major" territory="Washington D.C." quantity="1" owner="Americans"/>
-	<unitPlacement unitType="fighter" territory="Washington D.C." quantity="1" owner="Americans"/>
-            <unitPlacement unitType="airfield" territory="Washington D.C." quantity="1" owner="Americans"/>
-            <unitPlacement unitType="bomber" territory="Washington D.C." quantity="1" owner="Americans"/>
-            <unitPlacement unitType="infantry" territory="Washington D.C." quantity="1" owner="Americans"/>
-            <unitPlacement unitType="tactical_bomber" territory="Washington D.C." quantity="1" owner="Americans"/>
-            <unitPlacement unitType="artillery" territory="Washington D.C." quantity="1" owner="Americans"/>
-            <unitPlacement unitType="aaGun" territory="Washington D.C." quantity="1" owner="Americans"/>
+            <unitPlacement unitType="transport" territory="010 A Sea Zone" quantity="1" owner="Americans"/>
+            <unitPlacement unitType="destroyer" territory="010 A Sea Zone" quantity="1" owner="Americans"/>
+            <unitPlacement unitType="cruiser" territory="010 A Sea Zone" quantity="1" owner="Americans"/>
+            <unitPlacement unitType="destroyer" territory="010 B Sea Zone" quantity="1" owner="Americans"/>
+            <unitPlacement unitType="cruiser" territory="010 B Sea Zone" quantity="1" owner="Americans"/>
+            <unitPlacement unitType="submarine" territory="010 B Sea Zone" quantity="1" owner="Americans"/>
+            <unitPlacement unitType="transport" territory="010 B Sea Zone" quantity="1" owner="Americans"/>
+            <unitPlacement unitType="battleship" territory="010 B Sea Zone" quantity="1" owner="Americans"/>
+            <unitPlacement unitType="battleship" territory="026 B Sea Zone" quantity="3" owner="Americans"/>
+            <unitPlacement unitType="cruiser" territory="026 B Sea Zone" quantity="2" owner="Americans"/>
+            <unitPlacement unitType="fighter" territory="029 Sea Zone" quantity="1" owner="Americans"/>
+            <unitPlacement unitType="destroyer" territory="029 Sea Zone" quantity="1" owner="Americans"/>
+            <unitPlacement unitType="tactical_bomber" territory="029 Sea Zone" quantity="1" owner="Americans"/>
+            <unitPlacement unitType="submarine" territory="029 Sea Zone" quantity="1" owner="Americans"/>
+            <unitPlacement unitType="carrier" territory="029 Sea Zone" quantity="1" owner="Americans"/>
+            <unitPlacement unitType="destroyer" territory="035 A Sea Zone" quantity="1" owner="Americans"/>
+            <unitPlacement unitType="transport" territory="035 A Sea Zone" quantity="1" owner="Americans"/>
+            <unitPlacement unitType="submarine" territory="035 B Sea Zone" quantity="1" owner="Americans"/>
+            <unitPlacement unitType="airfield" territory="Agana-Guam" quantity="1" owner="Americans"/>
+            <unitPlacement unitType="infantry" territory="Agana-Guam" quantity="1" owner="Americans"/>
+            <unitPlacement unitType="infantry" territory="Anchorage" quantity="2" owner="Americans"/>
+            <unitPlacement unitType="infantry" territory="Bethel" quantity="1" owner="Americans"/>
+            <unitPlacement unitType="infantry" territory="Dovao-Mindonao" quantity="1" owner="Americans"/>
+            <unitPlacement unitType="artillery" territory="Dovao-Mindonao" quantity="1" owner="Americans"/>
+            <unitPlacement unitType="airfield" territory="Dovao-Mindonao" quantity="1" owner="Americans"/>
+            <unitPlacement unitType="harbour" territory="Dovao-Mindonao" quantity="1" owner="Americans"/>
+            <unitPlacement unitType="aaGun" territory="Dutch Harbor-Aleutian Is." quantity="1" owner="Americans"/>
+            <unitPlacement unitType="infantry" territory="Dutch Harbor-Aleutian Is." quantity="1" owner="Americans"/>
+            <unitPlacement unitType="infantry" territory="Hawaiian Is." quantity="2" owner="Americans"/>
+            <unitPlacement unitType="aaGun" territory="Hawaiian Is." quantity="1" owner="Americans"/>
+            <unitPlacement unitType="airfield" territory="Hawaiian Is." quantity="1" owner="Americans"/>
+            <unitPlacement unitType="harbour" territory="Hawaiian Is." quantity="1" owner="Americans"/>
+            <unitPlacement unitType="infantry" territory="Honolulu-Pearl Harbor" quantity="3" owner="Americans"/>
+            <unitPlacement unitType="airfield" territory="Honolulu-Pearl Harbor" quantity="1" owner="Americans"/>
+            <unitPlacement unitType="fighter" territory="Honolulu-Pearl Harbor" quantity="2" owner="Americans"/>
+            <unitPlacement unitType="aaGun" territory="Honolulu-Pearl Harbor" quantity="1" owner="Americans"/>
+            <unitPlacement unitType="harbour" territory="Honolulu-Pearl Harbor" quantity="1" owner="Americans"/>
+            <unitPlacement unitType="infantry" territory="King Salmon-Aleut Pen." quantity="1" owner="Americans"/>
+            <unitPlacement unitType="factory_minor" territory="Los Angeles-S.California" quantity="1" owner="Americans"/>
+            <unitPlacement unitType="infantry" territory="Los Angeles-S.California" quantity="2" owner="Americans"/>
+            <unitPlacement unitType="aaGun" territory="Los Angeles-S.California" quantity="1" owner="Americans"/>
+            <unitPlacement unitType="harbour" territory="Los Angeles-S.California" quantity="1" owner="Americans"/>
+            <unitPlacement unitType="airfield" territory="Los Angeles-S.California" quantity="1" owner="Americans"/>
+            <unitPlacement unitType="fighter" territory="Manila-Luzon" quantity="1" owner="Americans"/>
+            <unitPlacement unitType="infantry" territory="Manila-Luzon" quantity="2" owner="Americans"/>
+            <unitPlacement unitType="harbour" territory="Manila-Luzon" quantity="1" owner="Americans"/>
+            <unitPlacement unitType="airfield" territory="Manila-Luzon" quantity="1" owner="Americans"/>
+            <unitPlacement unitType="aaGun" territory="Manila-Luzon" quantity="1" owner="Americans"/>
+            <unitPlacement unitType="airfield" territory="Midway Is." quantity="1" owner="Americans"/>
+            <unitPlacement unitType="aaGun" territory="Midway Is." quantity="1" owner="Americans"/>
+            <unitPlacement unitType="infantry" territory="Midway Is." quantity="2" owner="Americans"/>
+            <unitPlacement unitType="infantry" territory="Nome" quantity="1" owner="Americans"/>
+            <unitPlacement unitType="infantry" territory="Panay Leyte-Visayas Is." quantity="1" owner="Americans"/>
+            <unitPlacement unitType="infantry" territory="Portland-Oregon" quantity="1" owner="Americans"/>
+            <unitPlacement unitType="infantry" territory="Sacramento-N.California" quantity="1" owner="Americans"/>
+            <unitPlacement unitType="factory_major" territory="San Francisco-Cen.California" quantity="1" owner="Americans"/>
+            <unitPlacement unitType="artillery" territory="San Francisco-Cen.California" quantity="1" owner="Americans"/>
+            <unitPlacement unitType="fighter" territory="San Francisco-Cen.California" quantity="1" owner="Americans"/>
+            <unitPlacement unitType="harbour" territory="San Francisco-Cen.California" quantity="1" owner="Americans"/>
+            <unitPlacement unitType="bomber" territory="San Francisco-Cen.California" quantity="1" owner="Americans"/>
+            <unitPlacement unitType="infantry" territory="San Francisco-Cen.California" quantity="1" owner="Americans"/>
+            <unitPlacement unitType="airfield" territory="San Francisco-Cen.California" quantity="1" owner="Americans"/>
+            <unitPlacement unitType="tactical_bomber" territory="San Francisco-Cen.California" quantity="1" owner="Americans"/>
+            <unitPlacement unitType="aaGun" territory="San Francisco-Cen.California" quantity="1" owner="Americans"/>
+            <unitPlacement unitType="aaGun" territory="Seattle-Washington" quantity="1" owner="Americans"/>
+            <unitPlacement unitType="infantry" territory="Seattle-Washington" quantity="2" owner="Americans"/>
+            <unitPlacement unitType="factory_minor" territory="Seattle-Washington" quantity="1" owner="Americans"/>
+            <unitPlacement unitType="infantry" territory="Wake Is." quantity="1" owner="Americans"/>
+            <unitPlacement unitType="aaGun" territory="Wake Is." quantity="1" owner="Americans"/>
+            <unitPlacement unitType="airfield" territory="Wake Is." quantity="1" owner="Americans"/>
+
+	<!-- Chinese -->
+            <unitPlacement unitType="infantry" territory="Aksu-Tarim" quantity="1" owner="Chinese"/>
+            <unitPlacement unitType="infantry" territory="Anhwei" quantity="3" owner="Chinese"/>
+            <unitPlacement unitType="infantry" territory="Chahar" quantity="3" owner="Chinese"/>
+            <unitPlacement unitType="infantry" territory="Chengdu-Szechwan" quantity="3" owner="Chinese"/>
+            <unitPlacement unitType="infantry" territory="Chungking" quantity="3" owner="Chinese"/>
+            <unitPlacement unitType="fighter" territory="Chungking" quantity="1" owner="Chinese"/>
+            <unitPlacement unitType="infantry" territory="Hailar-Hsingan" quantity="3" owner="Chinese"/>
+            <unitPlacement unitType="infantry" territory="Hunan" quantity="3" owner="Chinese"/>
+            <unitPlacement unitType="infantry" territory="Kanchow" quantity="2" owner="Chinese"/>
+            <unitPlacement unitType="infantry" territory="Kiangsi" quantity="4" owner="Chinese"/>
+            <unitPlacement unitType="infantry" territory="Kunming" quantity="2" owner="Chinese"/>
+            <unitPlacement unitType="infantry" territory="Kwangsi" quantity="4" owner="Chinese"/>
+            <unitPlacement unitType="infantry" territory="Kweichow" quantity="3" owner="Chinese"/>
+            <unitPlacement unitType="infantry" territory="Lanzhou" quantity="2" owner="Chinese"/>
+            <unitPlacement unitType="infantry" territory="Shensi" quantity="1" owner="Chinese"/>
+            <unitPlacement unitType="infantry" territory="Sikang" quantity="1" owner="Chinese"/>
+            <unitPlacement unitType="infantry" territory="Sinkiang" quantity="1" owner="Chinese"/>
+            <unitPlacement unitType="infantry" territory="Siuyuyan" quantity="2" owner="Chinese"/>
+            <unitPlacement unitType="infantry" territory="Tsinghai" quantity="1" owner="Chinese"/>
+            <unitPlacement unitType="infantry" territory="Urumchi-Kansu" quantity="1" owner="Chinese"/>
+            <unitPlacement unitType="artillery" territory="Yunnan" quantity="1" owner="Chinese"/>
+            <unitPlacement unitType="infantry" territory="Yunnan" quantity="3" owner="Chinese"/>
 
 	<!-- British -->
 	<unitPlacement unitType="factory_major" territory="London-S.England" quantity="1" owner="British"/>
@@ -6464,22 +6679,20 @@
             <unitPlacement unitType="harbour" territory="Sydney Canberra-New South Wales" quantity="1" owner="ANZAC"/>
             <unitPlacement unitType="armour" territory="Sydney Canberra-New South Wales" quantity="1" owner="ANZAC"/>
 
-	<!-- French -->
-	
 
 </unitInitialize>
       
     <resourceInitialize>
-      <resourceGiven player="Germans" resource="PUs" quantity="30"/>
-      <resourceGiven player="Russians" resource="PUs" quantity="37"/>
-      <resourceGiven player="Japanese" resource="PUs" quantity="26"/>
-      <resourceGiven player="British" resource="PUs" quantity="28"/>
-      <resourceGiven player="UK_Pacific" resource="PUs" quantity="17"/>
-      <resourceGiven player="ANZAC" resource="PUs" quantity="10"/>
-      <resourceGiven player="Italians" resource="PUs" quantity="10"/>
-      <resourceGiven player="Americans" resource="PUs" quantity="52"/>
-      <resourceGiven player="Chinese" resource="PUs" quantity="12"/>
-      <resourceGiven player="French" resource="PUs" quantity="19"/>
+      <resourceGiven player="Germans" resource="PUs" quantity="143"/>
+      <resourceGiven player="Russians" resource="PUs" quantity="147"/>
+      <resourceGiven player="Japanese" resource="PUs" quantity="78"/>
+      <resourceGiven player="Americans" resource="PUs" quantity="160"/>
+      <resourceGiven player="Chinese" resource="PUs" quantity="24"/>
+      <resourceGiven player="British" resource="PUs" quantity="0"/>
+      <resourceGiven player="UK_Pacific" resource="PUs" quantity="0"/>
+      <resourceGiven player="Italians" resource="PUs" quantity="0"/>
+      <resourceGiven player="ANZAC" resource="PUs" quantity="0"/>
+      <resourceGiven player="French" resource="PUs" quantity="0"/>
       <!--<resourceGiven player="Dutch" resource="PUs" quantity="0"/>-->
       <resourceGiven player="Japanese" resource="SuicideAttackTokens" quantity="6"/>
     </resourceInitialize>
@@ -6986,13 +7199,6 @@ Land Territories are changed in map.properties explained here<br>
 <b>Sea Zones</b> are explained here<br>
 <br>https://www.axisandallies.org/forums/topic/39809/new-triplea-map-uhd-world-war-ii-global/62?_=1709335922225<br>
 <br>
-Change Log:
-<br>
-<br>
-1.322<br>
-7-27-24<br>
-Add New German Placements Victory.<br>
-<br>
 To blitz move mech_infantry with armour, you must click on them both at the same time (use CTRL to create waypoints).<br>
 Paratroopers tech enables a second combat movement phase which happens right after the first combat movement phase, and the second one only allowes movement of paratrooping infantry.<br>
 <br>
@@ -7404,7 +7610,7 @@ These changes to units are things other than price/movement which you can see in
 <br>
 <br><br><hr><br>
 </div>
-						
+						 
 						]]></value>
     </property>
   </propertyList>


### PR DESCRIPTION
(Updated) setup for Germany, Russia, Japan, China, and America (Pacific) and IPC values for Germany, Russia, America, and 95% of the Pacific. Added ability for the Chinese to place units in any territory. Made all occupied Chinese territories originally owned by China.